### PR TITLE
update Mapserv vs Discover

### DIFF
--- a/data/base-map-and-imagery/index.md
+++ b/data/base-map-and-imagery/index.md
@@ -56,4 +56,4 @@ If you are not covered by the license agreement for the Google imagery service y
 AGRC has freely served online imagery services for many years. These imagery services and tiled caches are in the UTM NAD83 Zone 12 projection (wkid: 26912). The caches consist of between 3 to 17 million 256 pixel square jpg tiles and can range from 15G to over 200GB. These caches are standardized on a subset of the Google, Microsoft, and esri scale levels that apply to our state. Web developers can embed any of these services in web-based and internet-connected applications. More information about the services can be found on the [application developer]({{ "/developer/base-maps/" | prepend: site.baseurl }}) pages.
 
 - For imagery downloads visit [this page]({{ "/data/aerial-photography/" | prepend: site.baseurl }}).
-- Instructions on how to [use the Discover services in ArcMap]({{ "/data/sgid-base-map-services-arcmap/" | prepend: site.baseurl | append:"#utm-basemaps"}}).
+- Instructions on how to [use the Discover services in ArcMap]({{ "/data/sgid-base-map-services-arcmap/" | prepend: site.baseurl | append:"#web-mercator-services"}}).

--- a/data/base-map-and-imagery/index.md
+++ b/data/base-map-and-imagery/index.md
@@ -56,4 +56,4 @@ If you are not covered by the license agreement for the Google imagery service y
 AGRC has freely served online imagery services for many years. These imagery services and tiled caches are in the UTM NAD83 Zone 12 projection (wkid: 26912). The caches consist of between 3 to 17 million 256 pixel square jpg tiles and can range from 15G to over 200GB. These caches are standardized on a subset of the Google, Microsoft, and esri scale levels that apply to our state. Web developers can embed any of these services in web-based and internet-connected applications. More information about the services can be found on the [application developer]({{ "/developer/base-maps/" | prepend: site.baseurl }}) pages.
 
 - For imagery downloads visit [this page]({{ "/data/aerial-photography/" | prepend: site.baseurl }}).
-- Instructions on how to [use the mapserv services in ArcMap]({{ "/data/sgid-base-map-services-arcmap/" | prepend: site.baseurl | append:"#utm-basemaps"}}).
+- Instructions on how to [use the Discover services in ArcMap]({{ "/data/sgid-base-map-services-arcmap/" | prepend: site.baseurl | append:"#utm-basemaps"}}).


### PR DESCRIPTION
I changed the link information it read "use the Mapserv services in ArcMap"  but linked to how to use the Discover services, 

Part confuses me.......is says - Instructions on how to [use the Discover services in ArcMap]({{ "/data/sgid-base-map-services-arcmap/" | prepend: site.baseurl | append:"#utm-basemaps"}})."  not sure about the stuff after the | append.......

Pull request description
------------------------

