### PR TITLE
Other ftp links

### DIFF
--- a/data/boundaries/wilderness/index.html
+++ b/data/boundaries/wilderness/index.html
@@ -122,7 +122,7 @@ abstract="This dataset contains GIS mapping data pertaining to wilderness bounda
     <p>There are no constraints or warranties with regard to the use of this dataset. Users are encouraged to attribute content to: State of Utah, SGID. The dataset is maintained by the United States Forest Service.</p>
     <h5>Related Resources</h5>
     <ul class="dotless">
-      <li><a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_BOUNDARIES_Wilderness_BLMWSAs.html">FGDC format metadata</a>
+      <li><a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.BOUNDARIES.Wilderness_BLMWSAs.xml">FGDC format metadata</a>
     </ul>
     <p>Questions can be directed to <a href="mailto:agrc@utah.gov">AGRC</a> (801.538.3665) at AGRC.</p>
   </div>
@@ -139,7 +139,7 @@ abstract="This dataset contains GIS mapping data pertaining to wilderness bounda
     <p>BOUNDARIES.Wilderness_BLM98Reinventory dataset represents the 1998 Bureau of Land Management (BLM) Wilderness Characteristics Inventory. It represents the BLM's inventory of areas that have Wilderness Characteristics. The data set is at 1:24,000. The native spatial reference for this dataset is UTM Zone 12N, NAD83 (0.01 meter coordinate precision). There are no constraints or warranties with regard to the use of this dataset. Users are encouraged to attribute content to: State of Utah, SGID. The dataset is maintained by the United States Forest Service.</p>
     <h5>Related Resources</h5>
     <ul class="dotless">
-      <li><a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_BOUNDARIES_Wilderness_BLM98Reinventory.html">FGDC format metadata</a>
+      <li><a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.BOUNDARIES.Wilderness_BLM98Reinventory.xml">FGDC format metadata</a>
     </ul>
     <p>Questions can be directed to <a href="mailto:agrc@utah.gov">AGRC</a> (801.538.3665) at AGRC.</p>
   </div>
@@ -159,7 +159,7 @@ abstract="This dataset contains GIS mapping data pertaining to wilderness bounda
     <p>The native spatial reference for this dataset is UTM Zone 12N, NAD83 (0.01 meter coordinate precision). There are no constraints or warranties with regard to the use of this dataset. Users are encouraged to attribute content to: State of Utah, SGID. The dataset is maintained by the United States Forest Service.</p>
     <h5>Related Resources</h5>
     <ul class="dotless">
-      <li><a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_BOUNDARIES_Wilderness_BLMSuitability.html">FGDC format metadata</a>
+      <li><a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.BOUNDARIES.Wilderness_BLMSuitability.xml">FGDC format metadata</a>
     </ul>
     <p>Questions can be directed to <a href="mailto:agrc@utah.gov">AGRC</a> (801.538.3665) at AGRC.</p>
   </div>

--- a/data/cadastre/plss/index.html
+++ b/data/cadastre/plss/index.html
@@ -152,7 +152,7 @@ abstract="This dataset contains GIS mapping data representing the statewide Publ
     <p>The native spatial reference for this dataset is UTM Zone 12N, NAD83 (0.01 meter x,y coordinate precision; 0.001 mile m coordinate precision). There are no constraints or warranties with regard to the use of this dataset. Users are encouraged to attribute content to AGRC. This statewide dataset is maintained by AGRC in partnership with the BLM and local government. The geographic coordinates and their associated products are NOT legal land survey records. The coordinates can NOT be used as a substitute for a legal land survey. They can be used for record keeping, mapping, graphics and planning purposes only. No warranty is made by the Bureau of Land Management for use of the data for purposes not intended by BLM.</p>
     <h5>Related Resources</h5>
     <ul class="dotless">
-      <li><a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_CADASTRE_PLSSPoint_AGRC.html">FGDC format metadata</a>
+      <li><a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.CADASTRE.PLSSPoint_AGRC.xml">FGDC format metadata</a>
     </ul>
     <p>Questions can be directed to <a href="mailto:mheagin@utah.gov">Mike Heagin</a> (<em>801</em>-537-9296) or <a href="mailto:sfernandez@utah.gov">Sean Fernandez</a> P.L.S. (<em>801-209-9359</em>) at AGRC.</p>
   </div>

--- a/data/energy/energy-generation/index.html
+++ b/data/energy/energy-generation/index.html
@@ -23,4 +23,4 @@ This dataset also contains the ORIS Code, name, type, CO2 Annual Tons and fuel c
 <p><i class="fa fa-globe"></i> Usage: There are no constraints or warranties with regard to the use of this dataset.<br />
 <i class="fa fa-calendar"></i> Last Update: July 2008<br />
 <i class="fa fa-user"></i> Contact: <a href="mailto:agrc@utah.gov">AGRC</a><br />
-<i class="fa fa-link"></i> Links: <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_ENERGY_PowerPlants_CO2.html">FGDC Metadata</a> </p>
+<i class="fa fa-link"></i> Links: <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.ENERGY.PowerPlants_CO2.xml">FGDC Metadata</a> </p>

--- a/data/energy/uranium/index.html
+++ b/data/energy/uranium/index.html
@@ -182,7 +182,7 @@ Contact: <a href="mailto:agrc@utah.gov">AGRC</a></p>
 </ul>
 <p>Other links for this dataset:</p>
 <ul>
-<li><a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_ENERGY_UraniumDistricts_UGS.html">Uranium Districts (UGS): Metadata</a></li>
+<li><a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.ENERGY.UraniumDistricts_UGS.xml">Uranium Districts (UGS): Metadata</a></li>
 </ul>
 
         </div>

--- a/data/indices/usgs-dem-indices/index.html
+++ b/data/indices/usgs-dem-indices/index.html
@@ -81,7 +81,7 @@ USGSNationalElevationDataset:
     <h5>Related Resources</h5>
     <ul class="dotless">
       <li><a href="{{ "/data/elevation-terrain-data/10-30-meter-elevation-models-usgs-ned/" | prepend: site.baseurl }}">Download 10 and 30 meter USGS NED DEMs</a>
-      <li><a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_INDICES_NED10_Quads.html">View FGDC format metadata</a><br />
+      <li><a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.INDICES.NED10_Quads.xml">View FGDC format metadata</a><br />
     </ul>
     <p>Questions can be direction to <a href="mailto:rkelson@utah.gov">Rick Kelson</a> (801.538.3237) at AGRC.</p>
   </div>

--- a/data/society/state-fuel-sites/index.html
+++ b/data/society/state-fuel-sites/index.html
@@ -22,4 +22,4 @@ This dataset contains fuel sites for the State Of Utah and contains the site nam
 <p><i class="fa fa-globe"></i> Usage: There are no constraints or warranties with regard to the use of this dataset.<br />
 <i class="fa fa-calendar"></i> Last Update: 2009<br />
 <i class="fa fa-user"></i> Contact: <a href="mailto:agrc@utah.gov">AGRC</a><br />
-<i class="fa fa-link"></i> Links: <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_LOCATION_StateFuelSites.html">FGDC Metadata</a> </p>
+<i class="fa fa-link"></i> Links: <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.SOCIETY.StateFuelSites.xml">FGDC Metadata</a> </p>

--- a/data/transportation/air/index.html
+++ b/data/transportation/air/index.html
@@ -62,7 +62,7 @@ Heliports:
     <h5>Related Resources</h5>
     <ul class="dotless">
       <li class="productLink">
-        <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_Airports500K.html">View FGDC format metadata</a>
+        <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.TRANSPORTATION.AirportLocations.xml">View FGDC format metadata</a>
       </li>
     </ul>
   </div>

--- a/data/transportation/roads-system/index.html
+++ b/data/transportation/roads-system/index.html
@@ -169,7 +169,7 @@ abstract="This dataset contains GIS mapping data representing the statewide road
     <h5>Related Resource</h5>
     <ul class="dotless">
       <li><a href="http://data.udot.utah.gov">data.udot.utah.gov</a>
-      <li><a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_UDOTRoutes_LRS.html">FGDC format metadata</a>
+      <li><a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.TRANSPORTATION.UDOTRoutes_LRS.xml">FGDC format metadata</a>
     </ul>
   </div>
   {% include packagedata.html name="HighwayLinearReferencingSystemRoutes"

--- a/data/transportation/transit/index.html
+++ b/data/transportation/transit/index.html
@@ -108,7 +108,7 @@ UTALightRailStations:
     <h5>Related Resources</h5>
     <ul class="dotless">
       <li>
-        <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_CommuterRailRoute_UTA.html">FGDC format metadata (Rail Route)</a>
+        <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.TRANSPORTATION.CommuterRailRoutes_UTA.xml">FGDC format metadata (Rail Routes)</a>
       </li>
     </ul>
   </div>
@@ -130,7 +130,7 @@ UTALightRailStations:
     <h5>Related Resources</h5>
     <ul class="dotless">
       <li>
-        <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_CommuterRailStops_UTA.html">FGDC format metadata (Rail Stops)</a>
+        <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.TRANSPORTATION.CommuterRailStations_UTA.xml">FGDC format metadata (Rail Stations)</a>
       </li>
     </ul>
   </div>
@@ -154,9 +154,6 @@ UTALightRailStations:
     <ul class="dotless">
       <li>
         <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.TRANSPORTATION.LightRail_UTA.xml">FGDC format metadata (Light Rail)</a>
-      </li>
-      <li>
-        <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_LightRailNewRoutes_UTA.html">FGDC format metadata (Light Rail New Routes)</a>
       </li>
     </ul>
   </div>

--- a/data/transportation/transit/index.html
+++ b/data/transportation/transit/index.html
@@ -84,10 +84,10 @@ UTALightRailStations:
     <h5>Related Resources</h5>
     <ul class="dotless">
       <li>
-        <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_BusRoutes_UTA.html">FGDC format metadata (Bus Routes)</a>
+        <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.TRANSPORTATION.BusRoutes_UTA.xml">FGDC format metadata (Bus Routes)</a>
       </li>
       <li>
-        <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_BusStops_UTA.html">FGDC format metadata (Bus Stops)</a>
+        <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.TRANSPORTATION.BusStops_UTA.xml">FGDC format metadata (Bus Stops)</a>
       </li>
     </ul>
   </div>
@@ -153,7 +153,7 @@ UTALightRailStations:
     <h5>Related Resources</h5>
     <ul class="dotless">
       <li>
-        <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_LightRail_UTA.html">FGDC format metadata (Light Rail)</a>
+        <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.TRANSPORTATION.LightRail_UTA.xml">FGDC format metadata (Light Rail)</a>
       </li>
       <li>
         <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_LightRailNewRoutes_UTA.html">FGDC format metadata (Light Rail New Routes)</a>
@@ -179,7 +179,7 @@ UTALightRailStations:
     <h5>Related Resources</h5>
     <ul class="dotless">
       <li>
-        <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_TRANSPORTATION_LightRailStations_UTA.html">FGDC format metadata (Rail Stations)</a>
+        <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.TRANSPORTATION.LightRailStations_UTA.xml">FGDC format metadata (Rail Stations)</a>
       </li>
     </ul>
   </div>

--- a/data/water-data-services/watersheds/index.html
+++ b/data/water-data-services/watersheds/index.html
@@ -31,4 +31,4 @@ The HU_12_NAME field contains the subwatershed name<br />
 <br />
 <i class="fa fa-calendar"></i> Last Update: Unknown<br />
 <i class="fa fa-user"></i> Contact: <a href="mailto:agrc@utah.gov">AGRC</a><br />
-<i class="fa fa-link"></i> Links: <a href="ftp://ftp.agrc.utah.gov/SGID93_Vector/NAD83/MetadataHTML/SGID93_WATER_Watersheds_Area.html">FGDC Metadata</a> </p>
+<i class="fa fa-link"></i> Links: <a href="ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/Metadata/SGID10.WATER.Watersheds_Area.xml">FGDC Metadata</a> </p>


### PR DESCRIPTION
The final old metadata html links are gone. All FGDC metadata links should now be pointed at the new xml files.

closes #596

