### PR TITLE
Revert "Updated package link"

### DIFF
--- a/data/water/lakes-rivers-dams/index.html
+++ b/data/water/lakes-rivers-dams/index.html
@@ -44,7 +44,7 @@ NHDSprings:
   <img src="{{ "/images/Water.png" | prepend: site.baseurl }}" alt="Water" />
   <p class="caption-text">Water Sample</p>
 </div>
-{% include abstract.html download="https://drive.google.com/drive/folders/0ByStJjVZ7c7meXVsSUpKRFFCU3M"
+{% include abstract.html download="https://drive.google.com/drive/folders/0ByStJjVZ7c7mdjRzWWo0OUVKMVE"
 name="NHD Lakes, Rivers, Streams, and Springs"
 stewards="AGRC & USGS"
 abstract="The Lakes, Rivers, Streams & Springs data package contains feature layers that are derived from the <a href='http://nhd.usgs.gov/data.html'>National Hydrography Dataset (NHD)</a>. The NHD is the surface water component of the National Map created by the United States Geological Survey (USGS). The NHD contains a feature-based database that interconnects and uniquely identifies the stream segments or reaches that make up the nation's surface water drainage system. NHD data was originally developed at 1:100,000-scale and exists at that scale for the whole country. NHD data in it's entirety can be downloaded from <a href='ftp://nhdftp.usgs.gov/DataSets/Staged/States/FileGDB/HighResolution/'>here</a> (ex. NHDH_UT_)." %}


### PR DESCRIPTION
This reverts commit 398ea3ba1c83302dde1eef96f267b39c1418c6aa.

The original link was correct. It links to folders for the gdb and shapefiles. We thought those were zip files.

@keatonwalker pointed this out to me.

