### PR TITLE
metadata link does not work

### DIFF
--- a/data/demographic/census/index.html
+++ b/data/demographic/census/index.html
@@ -80,6 +80,8 @@ abstract="This data package contains demographic information collected by the Ce
     <h5>Related Resources</h5>
     <ul class="dotless">
       <li><a href="ftp://ftp.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_metc/society_census2010tiger/metadata/metadata.html#Entity_and_Attribute_Information">Metadata</a>
+       <li><a href="ftp://ftp.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_metc/society_census2010tiger/metadata/metadata.html#Entity_and_Attribute_Information">Metadata</a>
+       !need to udate the MN page here with https://www.mngeo.state.mn.us/committee/standards/mgmg/metaref.htm, if possible!
       <li><a href="https://www.census.gov/">U.S. Census Bureau</a>
     </ul>
     <p>{% include contact.html subject=page.title contact=site.data.contacts.agrc %}</p>


### PR DESCRIPTION

![CensusMetadataLink](https://user-images.githubusercontent.com/10677659/54542705-ee4a1a80-4961-11e9-8272-2d709b8381b0.JPG)
Not sure how this is going to work, the link from our page goes to a Minn. web page ftp://ftp.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_metc/society_census2010tiger/metadata/metadata.html#Entity_and_Attribute_Information
That link is fine but on that page there is a link to further information, but that is not our page....
http://www.gis.state.mn.us/stds/metadata.htm 
this link is no longer valid see the attachment, do we have to notify them?
Seems like it should be this, to get to the documents
https://www.mngeo.state.mn.us/committee/standards/mgmg/metaref.htm

Pull request description
------------------------

