### PR TITLE
Discover page edits

### DIFF
--- a/discover/index.html
+++ b/discover/index.html
@@ -15,31 +15,39 @@ categories: []
 ---
 
 <img src="images/discover.png" alt="Discover Logo" class="flex flex--center outline" />
-<h2 class="text-left"><i class="fas fa-fw fa-plane"></i> Getting Started</h2>
+<h2 class="text-left"><i class="fas fa-fw fa-plane"></i> About Discover</h2>
+<p>Discover is a cloud-based server that provides AGRC's aerial imagery and base maps to anyone who wants to use them in their GIS, CAD, or web applications. Discover's services are delivered in both <acronym title="Web Map Tile Service">WMTS</acronym> and <acronym title="Web Map Service">WMS</acronym> formats from the Open Geospatial Consortium (OGC) for broad compatibility. Like other common web map services, they are provided in the Web Mercator WGS84 projection (wkid/EPSG 3857).</p>
+<p>You will need to register for a free Discover account to access these services. There are two levels of Discover access:</p>
+<ul class="dotless">
+  <li><i class="far fa-fw fa-circle"></i> <strong>General access</strong>, for anyone who wants to use our base maps, NAIP imagery, or HRO imagery.</li>
+  <li><i class="fas fa-fw fa-lock"></i> <strong>Licensed access</strong>, for Utah's <strong>cities, counties, special districts, state agencies, K-12 or higher education, and tribal entities</strong> (or contractors or formal partners of any of these entities). This provides access to <strong>statewide 6" high-resolution aerial imagery</strong> under the State's <a href="{{ "/discover/license/" | prepend: site.baseurl }}">Google Imagery License</a> in addition to the general base maps and imagery.</li>
+</ul>
 <p class="pop text-center">
-  <strong>Anyone</strong> can use the AGRC imagery and base map services from Discover! To use these services, all you need is a <strong><em>free</em></strong> account and a <em>quad-word</em> connection link.
+  <strong>Anyone</strong> can use the general access imagery and base map services from Discover! To use these services, all you need is a <strong><em>free</em></strong> account and its corresponding quad-word connection link.
 </p>
 <h3 class="text-left"><i class="far fa-fw fa-keyboard"></i> Sign Up</h3>
 <h5>Choose the Right Form</h5>
-<p>To obtain access to Discover, you will need to fill out one of the following forms <strong>(A or B)</strong>:</p>
-<ol type="A">
-  <li>If you are requesting access on behalf of one of <strong>Utah’s: cities, counties, special districts, state agencies, K–12 or higher education, or tribal entities</strong>, or if you are a <strong>contractor and formal partner</strong> of one of these organizations, you are covered by our license agreement to access imagery provided by Google on Discover. In this case, please read and complete the <a href="https://docs.google.com/a/utah.gov/forms/d/e/1FAIpQLScL5uUQIvw7op_ZcF4bijxcoOMGhNF0MXwJNGqSXS6IbjbKhA/viewform">Organizational Usage Agreement Form</a> to obtain access. You can read more about our Google Imagery license <a href="{{ "/discover/license/" | prepend: site.baseurl }}">here</a>.
-  <li>If you are <strong>not</strong> part of one of the organizations listed above, please complete the <a href="https://docs.google.com/a/utah.gov/forms/d/e/1FAIpQLScvASb37-R9WeFHNUsbIYEcVzQ_ceT__G4PZUaCx_xZxTuEpA/viewform">Discover Server Access Form</a> to get access to all of the nonlicensed base maps and imagery services.
-</ol>
-<p>Once you have completed either form (<strong>please only fill out one</strong>), you will receive information about the services and a link to access the Discover Server.</p>
+<p><em><pre>You must choose. But choose wisely, for as the true form will bring you maps, the false form will take them from you.<br>     — The Grail Knight (probably)</pre></em></p>
+<p>To register a Discover account, fill out the appropriate form:</p>
+<ul class="dotless">
+  <li><i class="far fa-fw fa-circle"></i> <a href="https://docs.google.com/a/utah.gov/forms/d/e/1FAIpQLScvASb37-R9WeFHNUsbIYEcVzQ_ceT__G4PZUaCx_xZxTuEpA/viewform">Discover Server Access Form</a>, for <strong>general access</strong>.
+  <li><i class="fas fa-fw fa-lock"></i> <a href="https://docs.google.com/a/utah.gov/forms/d/e/1FAIpQLScL5uUQIvw7op_ZcF4bijxcoOMGhNF0MXwJNGqSXS6IbjbKhA/viewform">Organizational Usage Agreement Form</a>, for <strong>licensed access</strong> by one of Utah’s <strong>cities, counties, special districts, state agencies, K–12 or higher education, or tribal entities</strong>, or a contractor or formal partner of one of these organizations. Students in the state of Utah working on school projects also qualify for licensed access; please provide a school-supplied e-mail if possible.
+</ul>
+<p>Once you have completed the appropriate form (please only fill out <strong>one</strong> or the other, not both), we will review your request, create your account, and send you an e-mail with information about the services.</p>
 <h3 class="text-left" id="connect"><i class="fab fa-fw fa-mixcloud"></i> Get Connected</h3>
-<p>The URL that you receive to access the server will contain a quad-word (e.g., <code>https://discover.agrc.utah.gov/login/path/your-unique-quad-word/</code>) that is unique to you or your organization (i.e., unique to each user). Discover is able to serve many different clients by exposing <acronym title="Open GIS Consortium">OGC</acronym> compliant <acronym title="Web Map Service">WMS</acronym>, <acronym title="Web Map Tile Service">WMTS</acronym>, and direct tile access services.</p>
+<p>Your account e-mail will contain URLs that you'll enter into your software or web application to access the WMS, WMTS, or tile services. They contain a quad-word (e.g., <code>https://discover.agrc.utah.gov/login/path/your-unique-quad-word/</code>) that is unique to your user and should not be shared with anyone. Multiple requests from the same organization may be given the same quad-word.</p> 
 <strong>Example Discover URL Templates</strong>
 <ul class="dotless">
   <li>WMS: <code>https://discover.agrc.utah.gov/login/path/{quad-word}/wms</code>
   <li>WMTS: <code>https://discover.agrc.utah.gov/login/path/{quad-word}/wmts/1.0.0/WMTSCapabilities.xml</code>
   <li>Tiles: <code>https://discover.agrc.utah.gov/login/path/{quad-word}/tiles/{service}/{z}/{x}/{y}</code>
 </ul>
+<p>For best performance, we recommend using WMTS when possible.</p>
 <p>To learn more about using the Discover Server, be sure to visit our <a href="{{ "/discover/resources/" | prepend: site.baseurl }}">Discover Server Resources and Information</a> page. The following topics are covered in more depth on that page, but we've compiled them here as well for your convenience.</p>
 <ul class="dotless">
   <li><a href="{{ "/discover/resources/#coordinate-system-and-datum" | prepend: site.baseurl }}">Coordinate system and datum</a>
   <li><a href="{{ "/discover/resources/#horizontal-positional-accuracy" | prepend: site.baseurl }}">Horizontal positional accuracy</a>
-  <li><a href="{{ "/discover/resources/#adding-a-wmts-or-wms-service-to-arcmap" | prepend: site.baseurl }}">Adding a service in an Esri product</a>
+  <li><a href="{{ "/discover/resources/#adding-a-wmts-or-wms-service-to-esri-products" | prepend: site.baseurl }}">Adding a service in an Esri product</a>
   <li><a href="{{ "/discover/resources/#adding-a-wmts-or-wms-service-to-a-web-map" | prepend: site.baseurl }}">Adding a service in ArcGIS Online Web Maps</a>
   <li><a href="{{site.baseurl}}{% post_url 2015-12-21-using-agrcs-new-web-mercator-services-in-your-web-maps %}">Use in JavaScript/Web Mapping application</a>
   <li><a href="{{ "/discover/resources/#adding-a-wms-service-to-cad" | prepend: site.baseurl }}">Adding a service in CAD</a>
@@ -47,37 +55,38 @@ categories: []
   <li><a href="{{ "/discover/resources/#printing-web-maps-with-discover-services" | prepend: site.baseurl }}">Printing Discover services</a>
   <li><a href="{{ "/discover/resources/#google-flight-dates" | prepend: site.baseurl }}">Flight dates</a>
   <li><a href="{{ "/discover/resources/#requests-for-on-premise-use" | prepend: site.baseurl }}">On-premises use</a>
-  <li><a href="{{ "/discover/resources/#frequently-asked-questions" | prepend: site.baseurl }}">FAQ</a>
+  <li><a href="{{ "/discover/resources/#other-tidbits" | prepend: site.baseurl }}">Other tidbits</a>
 </ul>
 <p>If you are looking for <strong>imagery downloads</strong>, navigate to the <a href="{{ "/data/aerial-photography/" | prepend:site.baseurl }}">aerial photography</a> section of the data pages.</p>
 <h3 class="text-left" id="services"><i class="far fa-fw fa-map"></i> Available Services</h3>
 <ul class="dotless no-padding">
   <li><i class="fas fa-fw fa-lock"></i> <code>Utah</code> – Combination of the most recent 1-meter <abbr title="National Agriculture Imagery Program">NAIP</abbr> and 6-inch Google Imagery with scale-dependent rendering <strong>(licensed)</strong>
-  <li><i class="fas fa-fw fa-lock"></i> <code>Google</code> – Most recent 6-inch statewide natural-color aerial photography from Google collected over 2011 - 2018<strong>(licensed)</strong>
-  <li><i class="fas fa-fw fa-lock"></i> <code>Google {year} archive</code> – Aerial photography blocks updated in <code>Google</code> Service and archived by acquisition year <strong>(licensed)</strong>
+  <li><i class="fas fa-fw fa-lock"></i> <code>Google</code> – Most recent 6-inch statewide natural-color aerial photography from Google collected over 2011–2018<strong> (licensed)</strong>
+  <li><i class="fas fa-fw fa-lock"></i> <code>Google {year} archive</code> – Year-by-year updates to the Google Imagery (the latest blocks are always incorporated into the <code>Google</code> service) <strong>(licensed)</strong>
     <ul class="dotless no-margin">
       <li><em>Available Years: 2011–2016</em>
     </ul>
-  <li><i class="fas fa-fw fa-unlock"></i> <code>Basemap-Address_Points</code> – Base map of address point locations
-  <li><i class="fas fa-fw fa-lock"></i> <code>Basemap-Hybrid</code> – Base map combination of the overlay base map and Utah Imagery Service <strong>(licensed)</strong>
-  <li><i class="fas fa-fw fa-unlock"></i> <code>Basemap-Lite</code> – Base map of hillshade, highways and streets, cities, boundaries, etc. (gray, muted tone)
-  <li><i class="fas fa-fw fa-unlock"></i> <code>Basemap-Overlay</code> – Base map of vector features, highways and streets, cities, address points, parcels, etc. (transparent background)
-  <li><i class="fas fa-fw fa-unlock"></i> <code>Basemap-Terrain</code> – Base map of hillshade, highways and streets, parks, forests, water, etc.
-  <li><i class="fas fa-fw fa-unlock"></i> <code>Basemap-Topo</code> – Base map of US Geological Survey topographic maps
-  <li><i class="fas fa-fw fa-unlock"></i> <code><abbr title="Digital Ortho Photo Quads">DOQ</abbr> 1990s BW</code> – 1-meter statewide black-and-white aerial photography, collected in the 1990s
-  <li><i class="fas fa-fw fa-unlock"></i> <code><abbr title="High Resolution Othrophotography">HRO</abbr> 2012 RGB</code> – 12.5-cm natural-color aerial photography of the Wasatch Front, collected in 2012
-  <li><i class="fas fa-fw fa-unlock"></i> <code>NAIP {year} RGB</code> – 1-meter statewide natural-color aerial photography
+  <li><i class="far fa-fw fa-circle"></i> <code>Basemap-Address_Points</code> – Base map of <a href="{{ "data/location/address-data/#AddressPoints" | prepend: site.baseurl }}">address point</a> locations
+  <li><i class="far fa-fw fa-circle"></i> <code>Basemap-Overlay</code> – General reference features—highways and streets, cities, address points, parcels, etc—with a transparent background, suitable for layering over your thematic data.
+  <li><i class="fas fa-fw fa-lock"></i> <code>Basemap-Hybrid</code> – Combination of the <code>Overlay</code> base map and the <code>Utah</code> imagery service <strong>(licensed)</strong>
+  <li><i class="far fa-fw fa-circle"></i> <code>Basemap-Lite</code> – A light, muted reference base map that doesn't compete with your thematic data.
+  <li><i class="far fa-fw fa-circle"></i> <code>Basemap-Terrain</code> – Base map of hillshade, highways and streets, parks, forests, water, etc.
+  <li><i class="far fa-fw fa-circle"></i> <code>Basemap-Topo</code> – Base map of US Geological Survey topographic maps
+  <li><i class="far fa-fw fa-circle"></i> <code><abbr title="Digital Ortho Photo Quads">DOQ</abbr> 1990s BW</code> – 1-meter statewide black-and-white aerial photography, collected in the 1990s
+  <li><i class="far fa-fw fa-circle"></i> <code><abbr title="High Resolution Othrophotography">HRO</abbr> 2012 RGB</code> – 12.5-cm natural-color aerial photography of the Wasatch Front, collected in 2012
+  <li><i class="far fa-fw fa-circle"></i> <code>NAIP {year} RGB</code> – 1-meter statewide natural-color aerial photography
   <ul class="dotless no-margin">
     <li><em>Available Years: 2006, 2009, 2011, 2014, 2016</em>
   </ul>
-  <li><i class="fas fa-fw fa-unlock"></i> <code>NAIP {year} NRG</code> – 1-meter statewide color infrared aerial photography
+  <li><i class="far fa-fw fa-circle"></i> <code>NAIP {year} NRG</code> – 1-meter statewide color infrared aerial photography
   <ul class="dotless no-margin">
     <li><em>Available Years: 2006, 2011, 2014, 2016</em>
   </ul>
-  <li><i class="fas fa-fw fa-unlock"></i> <code>Hillshade</code> – 10-meter statewide combined hillshade and slope
+  <li><i class="far fa-fw fa-circle"></i> <code>Hillshade</code> – 10-meter statewide combined hillshade and slope
 </ul>
 <h3 class="text-left"><i class="far fa-fw fa-thumbs-up"></i> Best Practices</h3>
 <ul>
-  <li>It is strongly recommended that you use <code>WMTS</code> for the best draw time/perceived performance.
+  <li>It is strongly recommended that you use WMTS for the best draw time/perceived performance.
   <li>If you are, or will be, printing base maps from the web and are experiencing blank or empty output, read about our <a href="{{site.baseurl}}{% post_url 2017-02-02-printing-web-maps-with-discover-services %}">GP proxy service</a> or our new <a href="{{site.baseurl}}{% post_url 2018-02-26-success-with-serverless %}">serverless print proxy</a>.
+  <li>Any end products using the Google Imagery must attribute Google. See the <a href="{{ "/discover/resources/#google-logos" | prepend: site.baseurl }}">resources page</a> for logos.
 </ul>

--- a/discover/index.html
+++ b/discover/index.html
@@ -64,7 +64,7 @@ categories: []
   <li><i class="fas fa-fw fa-lock"></i> <code>Google</code> – Most recent 6-inch statewide natural-color aerial photography from Google collected over 2011–2018<strong> (licensed)</strong>
   <li><i class="fas fa-fw fa-lock"></i> <code>Google {year} archive</code> – Year-by-year updates to the Google Imagery (the latest blocks are always incorporated into the <code>Google</code> service) <strong>(licensed)</strong>
     <ul class="dotless no-margin">
-      <li><em>Available Years: 2011–2016</em>
+      <li><em>Available Years: 2011–2018</em>
     </ul>
   <li><i class="far fa-fw fa-circle"></i> <code>Basemap-Address_Points</code> – Base map of <a href="{{ "data/location/address-data/#AddressPoints" | prepend: site.baseurl }}">address point</a> locations
   <li><i class="far fa-fw fa-circle"></i> <code>Basemap-Overlay</code> – General reference features—highways and streets, cities, address points, parcels, etc—with a transparent background, suitable for layering over your thematic data.
@@ -76,11 +76,11 @@ categories: []
   <li><i class="far fa-fw fa-circle"></i> <code><abbr title="High Resolution Othrophotography">HRO</abbr> 2012 RGB</code> – 12.5-cm natural-color aerial photography of the Wasatch Front, collected in 2012
   <li><i class="far fa-fw fa-circle"></i> <code>NAIP {year} RGB</code> – 1-meter statewide natural-color aerial photography
   <ul class="dotless no-margin">
-    <li><em>Available Years: 2006, 2009, 2011, 2014, 2016</em>
+    <li><em>Available Years: 2006, 2009, 2011, 2014, 2016, 2018</em>
   </ul>
   <li><i class="far fa-fw fa-circle"></i> <code>NAIP {year} NRG</code> – 1-meter statewide color infrared aerial photography
   <ul class="dotless no-margin">
-    <li><em>Available Years: 2006, 2011, 2014, 2016</em>
+    <li><em>Available Years: 2006, 2011, 2014, 2016, 2018</em>
   </ul>
   <li><i class="far fa-fw fa-circle"></i> <code>Hillshade</code> – 10-meter statewide combined hillshade and slope
 </ul>

--- a/discover/license/index.md
+++ b/discover/license/index.md
@@ -12,25 +12,52 @@ categories: []
 ### Background
 {: .text-left}
 
-At the beginning of 2015, a coalition of state, regional, and local government agencies purchased a license to Google's high resolution (6 inch pixels) aerial photography. _Read the original [post]({{site.baseurl}}{% post_url 2015-02-02-utah-acquires-high-resolution-aerial-photography-license %}) about the acquisition_. The license will allow **Utah's cities, counties, special districts, state agencies, K12/Higher ed, and tribes** to use this imagery in web and desktop mapping  applications as a streaming web service or, where needed, on premise from downloaded local files. Also included is **use by contractors and formal partners of the immediate licensees**.
+At the beginning of 2015, a coalition of state, regional, and local government agencies purchased a license to Google's high resolution (6 inch pixels) aerial photography (_read the original post about the acquisition [here]({{site.baseurl}}{% post_url 2015-02-02-utah-acquires-high-resolution-aerial-photography-license %})_). This license allows **Utah's cities, counties, special districts, state agencies, K12/Higher ed, and tribes** to use the imagery in web and desktop mapping applications through a streaming web service or, where needed, on-premise from locally-stored files. The license also allows **use by contractors and formal partners of the immediate licensees**.
 
-The imagery web services will be hosted in Google's cloud and delivered via `WMS` and `WTMS` Open Geospatial Consortium (OGC) standards via AGRC's cloud-based server **Discover**. The original `.jp2` imagery tiles can be downloaded or obtainable from AGRC who has a master set of the raw imagery files.
+The imagery is hosted in Google's cloud and delivered as WMS and WTMS Open Geospatial Consortium (OGC) services via AGRC's **[Discover]({{ "/discover" | prepend: site.baseurl }})** basemap and imagery server. The original `.jp2` imagery tiles can be downloaded or obtained from AGRC, which keeps a master set of the imagery files.
+
+### Who Qualifies?
+{: .text-left}
+
+- Utah state agencies
+- Utah National Guard
+- Cities, counties, and other political subdivisions of the state of Utah
+- Special districts (water, fire, etc) in the state of Utah
+- Utah K-12 schools and institutions of higher education, including students working on school projects
+- Tribal entities
+
+### Who Doesn't Automatically Qualify?
+{: .text-left}
+
+- Federal agencies
+- US Military
+- Cities, counties, or state agencies outside of the state of Utah
+- Out-of-state schools
+- Non-profit entities
+- Professional groups and organizations
+- Community groups
+- Private individuals
+- Consultants and contractors
+
+**Note**: Federal agencies, US military entities, consultants, contractors, or other formal partners **can qualify** if they are directly performing work on behalf of a qaulified licensee, but only for the specific project in the contract.
+
+**_If you don't qualify for the Google imagery, you can sign up for Discover's general access services, which include NAIP imagery and the slightly older HRO imagery._**
 
 ### Sign Up Information
 {: .text-left}
 
-- View <a href="{{ "/data/google-imagery-license-signup" | prepend: site.baseurl }}">**Using Utah's Google Imagery License**</a> to learn about the sign up process for Utah's license to use Google's 6" imagery services.
-- **Find valuable information** about <a href="{{ "/data/googleimagery/" | prepend: site.baseurl }}">**Using the Google Imagery Service.**</a>
-- After reading the sign up and valuable information above, you'll need to complete the <a href="https://docs.google.com/a/utah.gov/forms/d/18FnT2fdg7nrA9xZYKUYV5UvxG0GO9w9DNFfeNG1D4TU/viewform">**Organizational Usage Agreement.**</a>
+If you qualify to use the Google imagery under the terms of the license, visit the main [Discover]({{ "/discover" | prepend: site.baseurl }}) page for sign up information and a link to the Organizational Usage Agreement.
 
-### Archive news and updates:
+**Check out valuable information** and FAQs about [using Discover services]({{ "/discover/resources" | prepend: site.baseurl }}).
+
+### Archive news and updates
 {: .text-left}
 
-- View initial announcement <a href="{{site.baseurl}}{% post_url 2015-02-02-utah-acquires-high-resolution-aerial-photography-license %}">Utah Acquires High Resolution Aerial Photography License.</a>
-- Using Utah's Google Imagery License <a href="{{site.baseurl}}{% post_url 2015-03-05-google-imagery-license-update-march-5th %}">(March 5th, 2015)</a>
-- Google Imagery <a href="{{site.baseurl}}{% post_url 2015-07-30-google-imagery-update-july-2015 %}"> (Update, July 2015)</a>
-- Google Imagery <a href="{{site.baseurl}}{% post_url 2015-11-24-google-imagery-service-speed-enhancements-more %}">(Update, November 2015)</a>
-- <i class="fab fa-youtube" aria-hidden="true"></i> Video <a href="https://youtu.be/Wch2M2rBJhU">Google Imagery License<i>Town Hall</i> meeting</a> presents background on the license, GIS and developer user info, and a look forward at future options.
+- Initial announcement: [Utah Acquires High Resolution Aerial Photography License]({{site.baseurl}}{% post_url 2015-02-02-utah-acquires-high-resolution-aerial-photography-license %}).
+- Using Utah's Google Imagery License [(March 5th, 2015)]({{site.baseurl}}{% post_url 2015-03-05-google-imagery-license-update-march-5th %})
+- Google Imagery [(Update, July 2015)]({{site.baseurl}}{% post_url 2015-07-30-google-imagery-update-july-2015 %})
+- Google Imagery [(Update, November 2015)]({{site.baseurl}}{% post_url 2015-11-24-google-imagery-service-speed-enhancements-more %})
+- <i class="fab fa-youtube" aria-hidden="true"></i> The [Google Imagery License Town Hall meeting](https://youtu.be/Wch2M2rBJhU) presents background on the license, GIS and developer user info, and a look forward at future options.
 
 {% capture license %}{% include contact.html subject=page.title contact=site.data.contacts.google_imagery %}{% endcapture %}
 {{ license | strip_newlines }}

--- a/discover/license/index.md
+++ b/discover/license/index.md
@@ -20,11 +20,12 @@ The imagery is hosted in Google's cloud and delivered as WMS and WTMS Open Geosp
 {: .text-left}
 
 - Utah state agencies
-- Utah National Guard
 - Cities, counties, and other political subdivisions of the state of Utah
 - Special districts (water, fire, etc) in the state of Utah
 - Utah K-12 schools and institutions of higher education, including students working on school projects
 - Tribal entities
+- Contractors and formal partners of an immediate licensee
+- Utah National Guard
 
 ### Who Doesn't Automatically Qualify?
 {: .text-left}

--- a/discover/resources/index.md
+++ b/discover/resources/index.md
@@ -11,16 +11,12 @@ title: Discover Server Resources and Information
 categories: []
 ---
 
-### Discover Server
+## <i class="fas fa-fw fa-plane"></i> Discover Server
 {: .text-left}
 
-AGRC’s cloud-based server Discover provides imagery and base maps services in Open Geospatial Consortium (OGC) standard Web Map Tile Service (WMTS) and Web Map Service (WMS) in the Web Mercator WGS84 projection (wkid: 3857).
+Discover provides high-performance imagery and base maps services in WMS and WMTS formats. For information about the services and directions to sign up, please see the main [Discover]({{ "/discover/" | prepend: site.baseurl }}) page.
 
-One featured offering from Discover is statewide 6 inch imagery collected and licensed by Google. Due to this licensed content, access to the Google imagery is only for **Utah’s cities, counties, special districts, state agencies, K12/Higher education, and tribes and contractors and formal partners of the immediate licensees.** To obtain access to the Discover server you need to fill out and understand the **[Organizational Usage Agreement](https://docs.google.com/a/utah.gov/forms/d/e/1FAIpQLScL5uUQIvw7op_ZcF4bijxcoOMGhNF0MXwJNGqSXS6IbjbKhA/viewform)** available from the **[Google Imagery License]({{"/discover/license/" | prepend: site.baseurl }})** page. Once the Organizational Usage Agreement is completed, you will receive information about the services and URL links to access the Discover server. The URLs to access the server will contain a quad-word (ex. `https://discover.agrc.utah.gov/login/path/your-unique-quad-word/`) unique to each user or organization.
-
-If you are not covered by the license agreement for the Google imagery service you will need to fill out the **[Discover Server Access](https://docs.google.com/a/utah.gov/forms/d/e/1FAIpQLScvASb37-R9WeFHNUsbIYEcVzQ_ceT__G4PZUaCx_xZxTuEpA/viewform)** form. Once the form has been completed, you will receive information about the services and URL links to access the Discover server. The URLs to access the server will contain a quad-word (ex. `https://discover.agrc.utah.gov/login/path/your-unique-quad-word/`) unique to each user or organization.
-
-- For imagery downloads visit [this page]({{ "/data/aerial-photography/" | prepend: site.baseurl }}).
+- For imagery downloads visit the [aerial photography data page]({{ "/data/aerial-photography/" | prepend: site.baseurl }}).
 - Instructions on how to [use the Discover services in Pro/ArcMap](#adding-a-wmts-or-wms-service-to-esri-products).
 - Instructions on how to [use the Discover services in CAD](#adding-a-wms-service-to-cad).
 - Instructions on how to [use the Discover services in Web Maps]({{site.baseurl}}{% post_url 2015-12-21-using-agrcs-new-web-mercator-services-in-your-web-maps %}).
@@ -28,31 +24,32 @@ If you are not covered by the license agreement for the Google imagery service y
 ### Coordinate System and Datum
 {: .text-left}
 
-The native coordinate system for the Google files and services is Web Mercator with a WGS 1984 datum. Many end users in Utah work in coordinate systems with a different datum (NAD 1983 for example). It will be critical for end users that require the highest locational precision to set up their working environment through the use of the appropriate geographic transformation. The geographic transformation parameter is needed to overcome the locational difference between the WGS84 and NAD83 datum's “realization points” that are about a meter apart. Without the proper geographic transformation, reprojection algorithms will not be able to resolve the last meter of positional accuracy. In order for the imagery to be positioned as accurately as possible when there is a difference between the native projection and datums of the imagery and the client viewing application, a [datum conversion]({{ "/downloads/Transformation.png" | prepend: site.baseurl }}) must be set. AGRC uses the `NAD_1983_To_WGS_1984_5` transformation when creating base map tiles and web applications. **There may be more accurate transformations based on the data you are working with**. The default (no transformation specified) will likely introduce several feet of horizontal positional error. More information: [NAD_1983_To_WGS_1984_5](https://support.esri.com/en/knowledgebase/techarticles/detail/24159)
+The native coordinate system for the Discover services is Web Mercator with a WGS 1984 datum (EPSG 3857). Many users work in coordinate systems with a different datum (for example, EPSG 3566: Utah Central with NAD 1983). It is critical for users who need the highest locational precision to use the appropriate [geographic transformation conversion]({{ "/downloads/Transformation.png" | prepend: site.baseurl }}). This remedies the roughly one meter difference between the WGS84 and NAD83 datums' “realization points.” Without the right transformation, you will not be able to get the highest level of positional accuracy. AGRC uses the `NAD_1983_To_WGS_1984_5` transformation when creating base map tiles and web applications, but **there may be more accurate transformations based on the data and area you are working with**. The default (no transformation specified) will likely introduce several feet of horizontal positional error. More information about these transformations can be found on ESRI's [NAD 1983 To WGS 1984](https://support.esri.com/en/knowledgebase/techarticles/detail/24159) How-To.
 
 ### Horizontal Positional Accuracy
 {: .text-left}
 
-Stated horizontal positional accuracy of the Google imagery is expected to achieve or exceed one meter (CE90) in most areas without significant vertical relief. Higher precision is expected in urban areas, where existing supplemental ground control was more abundant.
+Stated horizontal positional accuracy of the Google imagery is expected to achieve or exceed one meter (CE90) in most areas without significant vertical relief. You can generally expect higher precision in urban areas where existing supplemental ground control was more abundant.
 
-### Adding a WMTS or WMS Service to esri Products
+### Adding a WMTS or WMS Service to ESRI Products
 {: .text-left}
 
 **ArcGIS Pro 2.x:**
 
 1. `Insert -> Connections -> New WMTS Server`
-1. Paste the `WMTS` link [you have been provided]({{ "/discover/license/" | prepend: site.baseurl }} "view Discover sign up information") into the `Server URL:` line and click `OK`
+1. Paste the `WMTS` link [you have been provided]({{ "/discover/#connect" | prepend: site.baseurl }} "view Discover sign up information") into the `Server URL:` line and click `OK`
 1. Navigate to the newly added `utah imagery - WMTS on discover.agrc.utah.gov.wmts` connection under `Servers` in the Catalog window.
-1. Expand the nodes until you see a list of all of the imagery and base map services that are offered. The list can be viewed on the main [Discover]({{ "/discover/#services" | prepend: site.baseurl }}) page.
+1. Expand the nodes until you see a list of all of the imagery and base map services that are available to your login. The full list can be viewed on the main [Discover]({{ "/discover/#services" | prepend: site.baseurl }}) page.
+1. Add your desired service to your map like you would any other layer.
 
 **ArcMap 10.x**
 
-1. In ArcMap go to `Add Data -> GIS Server -> Add WMTS server`
-1. Paste the `WMTS` link [you have been provided]({{ "/discover/license/" | prepend: site.baseurl }} "view Discover sign up information") into the `URL:` line and click `OK`
+1. `Add Data -> GIS Server -> Add WMTS server`
+1. Paste the `WMTS` link [you have been provided]({{ "/discover/#connect" | prepend: site.baseurl }} "view Discover sign up information") into the `URL:` line and click `OK`
 1. Navigate to the newly added `utah imagery – WMTS on discover.agrc.utah.gov` connection and **double click** to connect.
   - You can rename the connection after it has been added
-1. Expand the nodes until you see a list of all of the imagery and base map services that are offered. The list can be viewed on the main [Discover]({{ "/discover/#services" | prepend: site.baseurl }}) page.
-
+1. Expand the nodes until you see a list of all of the imagery and base map services that are avialbe to your login. The list can be viewed on the main [Discover]({{ "/discover/#services" | prepend: site.baseurl }}) page.
+1. Add your desired service to your map like you would any other layer.
 
 ### Adding a WMTS or WMS Service to a Web Map
 {: .text-left}
@@ -65,7 +62,7 @@ Interested in using AGRC's Web Mercator services in your web maps? Take a look a
 {: .text-left}
 
 - **Bentley Microstation** users should take a look at the [How To document]({{ "/downloads/MicroStationGoogleWMS_HowTo.pdf" | prepend: site.baseurl }}).
-- **AutoCAD Civil 3D 2016** users should take a look at the [How To document](https://us-support.nearmap.com/hc/en-us/articles/212242658-AutoCAD-Civil-3D-2016-WMS-Integration).
+- **AutoCAD Civil 3D** users should take a look at the [How To document](https://knowledge.autodesk.com/support/autocad-map-3d/learn-explore/caas/CloudHelp/cloudhelp/2017/ENU/MAP3D-Use/files/GUID-A9F620AD-6B9A-487D-9B33-7D365307D571-htm.html).
 
 ### Printing Web Maps with Discover Services
 {: .text-left}
@@ -75,37 +72,43 @@ Take a look at this blog post for information about [Printing Web Maps with Disc
 ### Google Archive Services
 {: .text-left}
 
-In addition to the statewide `Google` imagery service layer there are archive layers available (ex. `Google 2011archive`) of the Google imagery organized by year collected.
+<i class="fas fa-fw fa-lock"></i> 
+In addition to the statewide `Google` imagery service layer, there are archive layers available (ex. `Google 2011archive`) of the Google imagery organized by year collected.
 
 ### Google Flight Dates
 {: .text-left}
 
-The [dates of each Google imagery flight](ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/INDICES/UnpackagedData/Google_UtahServiceDates/_Statewide/) block can be downloaded from our ftp site as a shapefile, viewed in [ArcGIS Online](https://arcg.is/1E0wq3b), or utilized through our SDE as layer `SGID10.INDICES.Google_UtahServiceDates`.
+<i class="fas fa-fw fa-lock"></i> 
+The [dates of each Google imagery flight](ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/INDICES/UnpackagedData/Google_UtahServiceDates/_Statewide/) block can be downloaded from our ftp site as a shapefile, viewed in [ArcGIS Online](https://arcg.is/1E0wq3b), or utilized through the `SGID10.INDICES.Google_UtahServiceDates` SGID layer.
 
 ### Pro/ArcMap User Considerations
 {: .text-left}
 
 {%capture contact2 %}{% include contact.html subject=page.title contact=site.data.contacts.discover text='please contact' %}{% endcapture %}
 
-If you have not yet received quad-word links to the service (ex. `https://discover.agrc.utah.gov/login/path/your-unique-quad-word/`) that do not require a username and password {{ contact2 | strip_newlines }}
+Legacy username/password users: If you have not yet received quad-word links to the service (ex. `https://discover.agrc.utah.gov/login/path/your-unique-quad-word/`) that do not require a username and password, {{ contact2 | strip_newlines }}
 
-Users experiencing problems with the service, such as blurry tiles or different year vintages at different scales, may need to clear their local cache.
+Users experiencing problems with the service, such as blurry tiles or different year vintages at different scales, may need to clear their local cache:
 
 - **ArcMap** Go to the service’s `Layer Properties -> Cache` tab and selecting `Clear Local Cache Now`. Be patient as this could take several minutes. If the blurry tiles persist you have the options to `Clear cache when the session ends` or `Don't cache any data locally`. Another option is to completely clear your ArcMap cache by going to `Customize -> ArcMap Options -> Display Cache -> Clear Cache`.
 
 - **ArcGIS Pro** Go to the service’s `Layer Properties -> Cache` tab and selecting `Clear Cache`. You can also clear your entire Pro cache by going to the Pro project's `Options -> Display` and check `Clear cache` and selecting `OK`.
 
-**ArcMap 10.1 users** should use the WMS service and not the WMTS. The WMTS in ArcMap 10.1 does not render correctly.
+**ArcMap 10 and 10.1 users** should use WMS instead of WMTS. ArcMap 10 and below do not support WMTS, and ArcMap 10.1 [has issues](https://community.esri.com/thread/58788) rendering WMTS data.
 
 ### Usage Tracking
 {: .text-left}
 
-To access the GCP services individual organizations will be provided URL links for the service unique to their organization. This will allow for tracking usage metrics and performance of the imagery service. Do not distribute the URL links outside of your organization or division.
+Individual organizations will be provided URL links for the Discover services that are unique to their organization. This will allow us to track general usage metrics and monitor the performance of the services. Do not distribute your URL links outside of your organization or division.
 
 ### Google Logos
 {: .text-left}
 
+<i class="fas fa-fw fa-lock"></i>
+Our license with Google requires you to put the appropriate logo on any products made using the Google imagery.
+
 [Download zipfile of Google logos]({{ "/downloads/google_logos.zip" | prepend: site.baseurl }})
+
 ![white transparent]({{ "/images/ImageryCGoogle_WhiteTransparent.png" | prepend: site.baseurl }})
 ![white on black]({{ "/images/ImageryCGoogle_WhiteOnBlack.png" | prepend: site.baseurl }})
 
@@ -114,19 +117,19 @@ To access the GCP services individual organizations will be provided URL links f
 
 {%capture contact3 %}{% include contact.html subject=page.title contact=site.data.contacts.discover text='Please provide the following information to' hide-punctuation=true %}{% endcapture %}
 
-Request can be made to consume the imagery off-line when the provided imagery service does not suffice. {{ contact3 | strip_newlines }} for consideration:
+You may request a local copy of the NAIP, HRO, and Google imagery for off-line consumption when the provided imagery service does not meet your needs. {{ contact3 | strip_newlines }} for consideration:
   -	Name & organization:
   - Reason for request:
   - Working on behalf of:
   - Project names:
   - Project locations:
 
-### Frequently Asked questions
+### Other Tidbits
 {: .text-left}
 
 - From time to time it is suggested that you refresh the connection to the imagery services by right-clicking your service connection, in ArcCatalog or ArcMap's Catalog Viewer, and select the `Refresh`  button to see the latest list of available services.
 - Since the Google acquisition flight blocks are not done all at once (as opposed to the NAIP product for example), there will certainly be color and positional changes at flight block boundaries. For large area maps, the color-balanced NAIP may be a more aesthetically pleasing cartographic choice.
-- A tile index of the .jp2 images that make up the service is available from our SDE as SGID10.INDICES.Google_Tiles or as a [download from our ftp](ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/INDICES/UnpackagedData/Google_Tiles/_Statewide/).
-- For future updates, Utah can certainly pass along requests to Google for additional update areas or for specific collection periods. But there is no provision in the current contract to create any expectation that those requests will be acted upon.
+- A tile index of the original .jp2 images that make up the Google imagery services is available from the SGID as SGID10.INDICES.Google_Tiles or as a [download from our ftp](ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/INDICES/UnpackagedData/Google_Tiles/_Statewide/).
+- For future imagery updates, we can certainly pass along requests to Google for additional update areas or for specific collection periods. However, there is no provision in the current contract to create any expectation that those requests will be acted upon.
 - AGRC has downloaded a statewide master set of the image files for redistribution, as the download process directly from Google incurs transactional costs for cloud server & bandwidth usage.
-- AGRC has a [feedback reporting form](https://docs.google.com/a/utah.gov/forms/d/1UGU77SPM_HX0r8zblIs05C-H5mLyRja1gRT7Fu4aKZk/viewform?fbzx=-6743712545663240221) for imagery users around the state to report imagery and service issues so these can be passed along to Google. Please direct your feed back to the form.
+- AGRC has a [feedback reporting form](https://docs.google.com/a/utah.gov/forms/d/1UGU77SPM_HX0r8zblIs05C-H5mLyRja1gRT7Fu4aKZk/viewform?fbzx=-6743712545663240221) for imagery users around the state to report imagery and service issues so they can be passed along to Google. Please submit your feed back through this form.


### PR DESCRIPTION
I've made some changes to the Discover pages to hopefully help people choose the right access level and associated request form. Rick suggested I do a WIP pull request to allow him to review the changes before they get pulled in.

In brief:

- Restructured so that main page is general info on Discover, brief description of licensed vs general access, and sign-up links; resources page is specific topics related to using Discover without much about the licensing; license page describes the Google license and lists of who does/does not qualify.
- Tried to put everything in concise, active voice.
- Standardized the intentional use of "Google imagery" to refer to the licensed products and "Discover services" for everything else.