### PR TITLE
Revert Open Data beta™ links

### DIFF
--- a/data/cadastre/parcels/index.html
+++ b/data/cadastre/parcels/index.html
@@ -45,148 +45,148 @@ abstract="Parcel data contains GIS mapping data representing parcel boundaries. 
         </tr>
         <tr>
           <td><a title="county website" href="https://beaver.utah.gov/" target="_blank" rel="noopener">Beaver</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-beaver-county-parcels">July 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-beaver-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7meGdBcUdJM0hZX3c">July 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mdElCWXQ4Y0s3ekk">2019</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="http://gis.boxeldercounty.org/webmap/" target="_blank" rel="noopener">Box Elder</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-box-elder-county-parcels">July 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-box-elder-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mdlg3Z0NETXdQRHM">July 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mbXdIVC1FZGF2bzA">2019</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="https://www.cachecounty.org/gis/property-/-parcel-viewer.html" target="_blank" rel="noopener">Cache</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-cache-county-parcels">September 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-cache-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7meUVJTUpPbTFya1U">September 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mMXRaQVM3V0o1Q1E">2019</a></td>
         </tr>
         <tr>
           <td><a title="county web app" href="http://maps.carbon.utah.gov/flexviewer/CarbonCountyGeneralMap/" target="_blank" rel="noopener">Carbon</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-carbon-county-parcels">October 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-carbon-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mZWZHakFvQjVJSEk">October 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mYnJCb0VaQTRWWFk">2018</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="https://www.daggettcounty.org/" target="_blank" rel="noopener">Daggett</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-daggett-county-parcels">August 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-daggett-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7md1FYZDkzWjZkZEE">August 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7maEhrM1RDdGJjczA">2019</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="https://www.co.davis.ut.us/recorder/property-search" target="_blank" rel="noopener">Davis</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-davis-county-parcels">February 2020</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-davis-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mUFMxN1MySU5kMVE">February 2020</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mR2Q3Q2hGMGRiM2s">2019</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="https://duchesnecounty.maps.arcgis.com/apps/webappviewer/index.html?id=90c3cc34ed1a47c79d2b4b508ee9e507" target="_blank" rel="noopener">Duchesne</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-duchesne-county-parcels">March 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-duchesne-county-parcels-lir">2017</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mYnIzNjYzZEl5Q2s">March 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/1KhrbKaJedEAP9fesYEVuI258ex86ahYT">2017</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://www.emerycounty.com/" target="_blank" rel="noopener">Emery</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-emery-county-parcels">July 2019</a></td>
-          <td></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mZDJtd1Rub0l6N00">July 2019</a></td>
+          <td><a href=""></a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://garfield.utah.gov/" target="_blank" rel="noopener">Garfield</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-garfield-county-parcels">February 2018</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-garfield-county-parcels-lir">2017</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mSEN0RTJVT3VBUUE">February 2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mYUQ0eFg2QVJwSW8">2017</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="https://www.grandcountyutah.net/790/Parcel-Viewer-Map" target="_blank" rel="noopener">Grand</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-grand-county-parcels">February 2020</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-grand-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mbmp0UGNxbFRkT3c">February 2020</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mT1VZSUg1VmlmaFU">2018</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="https://irongis.maps.arcgis.com/apps/webappviewer/index.html?id=3d8b2640346f452394cb7a9ced8f461c" target="_blank" rel="noopener">Iron</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-iron-county-parcels">August 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-iron-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mVV9oQWpqS2FxN3c">August 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mSXVSaG1QR21XenM">2019</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://www.co.juab.ut.us/" target="_blank" rel="noopener">Juab</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-juab-county-parcels">November 2018</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-juab-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mcm5RaFRrV0lPcjg">November 2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mUWZUOVVDSzJwM3c">2018</a></td>
         </tr>
         <tr>
           <td><a title="county parcel search" href="http://eagleweb.kane.utah.gov/eaglesoftware/web/login.jsp" target="_blank" rel="noopener">Kane</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-kane-county-parcels">February 2020</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-kane-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mUUt2dzV4SmN0WHc">February 2020</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mcWtOZTJzUmdLTTA">2019</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="https://www.millardcounty.org/" target="_blank" rel="noopener">Millard</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-millard-county-parcels">July 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-millard-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mU2FRLWs1eUZxMnM">July 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mYm9ueWxzS0ZkM2s">2018</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://www.morgan-county.net/" target="_blank" rel="noopener">Morgan</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-morgan-county-parcels">December 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-morgan-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mUXpzSUNOdTZDT3M">December 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mV3h1c3NWOW9UMVU">2019</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://www.piute.org/" target="_blank" rel="noopener">Piute</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-piute-county-parcels">March 2019</a></td>
-          <td></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mOWcxOGhyTFB4SGc">March 2019</a></td>
+          <td><a href=""></a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://www.richcountyut.org/" target="_blank" rel="noopener">Rich</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-rich-county-parcels">November 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-rich-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mMWYtZFBLXzFHT0U">November 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/1SVE03iF8hLVrBKusZ31pOiZdT5j-mHaT">2018</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="https://slco.org/assessor/new/query/intropage.cfm" target="_blank" rel="noopener">Salt Lake</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-salt-lake-county-parcels">February 2020</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-salt-lake-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mb0UtNFlaWjZ1YlE">February 2020</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mT3BVTnpyQzNmdFk">2019</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="https://www.sanjuancounty.org/" target="_blank" rel="noopener">San Juan</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-san-juan-county-parcels">May 2014</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-san-juan-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mZXhUcEZsOEdOSWM">May 2014</a></td>
+          <td><a href="https://drive.google.com/drive/folders/1Tm-1dk71IEOSaGPlKUm4vBH0oJCoWqz-">2018</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://sanpete.com/" target="_blank" rel="noopener">Sanpete</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-sanpete-county-parcels">October 2015</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-sanpete-county-parcels-lir">2017</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mNVlCanlhTE1Ya2c">October 2015</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mVU03RTJwdUxPNnM">2017</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="https://www.sevierutah.net/" target="_blank" rel="noopener">Sevier</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-sevier-county-parcels">June 2011</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-sevier-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mR3R0VGRQdDZkems">June 2011</a></td>
+          <td><a href="https://drive.google.com/drive/folders/1lkzhqfbKeNWmnQTqTYaFqkgehnirYFva">2018</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="http://maps.summitcounty.org/flexviewers/countymap/" target="_blank" rel="noopener">Summit</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-summit-county-parcels">February 2020</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-summit-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mUHVMS2RxVjhrdmM">February 2020</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mc0xJZGtCMWpsNWc">2018</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://www.co.tooele.ut.us/" target="_blank" rel="noopener">Tooele</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-tooele-county-parcels">November 2019</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-tooele-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mSkpPakNOeWZ6Skk">November 2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mRDNrVFhmTGhzNVk">2018</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://www.co.uintah.ut.us/" target="_blank" rel="noopener">Uintah</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-uintah-county-parcels">January 2019</a></td>
-          <td></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7malh2WEljN2N4aDg">January 2019</a></td>
+          <td><a href=""></a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="http://maps4.utahcounty.gov/ParcelMap/ParcelMap.html" target="_blank" rel="noopener">Utah</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-utah-county-parcels">February 2020</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-utah-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mWlV1M21QeW5Bd1k">February 2020</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mVFk3cGpTY0JaMEk">2019</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="https://wasatch.maps.arcgis.com/apps/webappviewer/index.html?id=fe65f93c14a84f44814a81f97fa0fa5b" target="_blank" rel="noopener">Wasatch</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-wasatch-county-parcels">January 2020</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-wasatch-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mTzFNaXROcnVsYm8">January 2020</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mWmNWQUtaVUVkWm8">2019</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="http://geo.washco.utah.gov/Html5Viewer/?viewer=RecordersOffice" target="_blank" rel="noopener">Washington</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-washington-county-parcels">February 2020</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-washington-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mZFZUZ0NoSl9MalE">February 2020</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mbHJQQnBpWWt0eWM">2019</a></td>
         </tr>
         <tr>
           <td><a title="county website" href="http://www.waynecountyutah.org/" target="_blank" rel="noopener">Wayne</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-wayne-county-parcels">July 2010</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-wayne-county-parcels-lir">2018</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mbVpDa1JFbDZDeGM">July 2010</a></td>
+          <td><a href="https://drive.google.com/drive/folders/1P-kIbhXarRbErA-fBnrUFo2mwwbuxUST">2018</a></td>
         </tr>
         <tr>
           <td><a title="county parcel web app" href="https://www3.co.weber.ut.us/psearch/" target="_blank" rel="noopener">Weber</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-weber-county-parcels">February 2020</a></td>
-          <td><a href="https://opendata.gis.utah.gov/datasets/utah-weber-county-parcels-lir">2019</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7meWRjQzdRTFh1VHM">February 2020</a></td>
+          <td><a href="https://drive.google.com/drive/folders/0ByStJjVZ7c7mMnZKMWdIbXZvQWM">2019</a></td>
         </tr>
         <tr>
           <td colspan="2"></td>

--- a/data/location/address-data/index.html
+++ b/data/location/address-data/index.html
@@ -10,9 +10,11 @@ author:
 date: 2012-08-15 16:09:42 -0600
 categories: []
 AddressPoints:
-  hub:
-    name: Utah Address Points
-    item_id: 3f4f7a8efcd147febeca8bacaea67a14
+  downloads:
+    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mT3lEdGdtS01YeGs&export=download
+      label: 'Statewide Address Points: File Geodatabase'
+    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mUlFsVlBoSTFhS3M&export=download
+      label: 'Statewide Address Points: Shapefile'
   updates:
     - February 2020 - Box Elder, Davis, Iron, Salt Lake, Summit, Utah, Washington, Weber Counties
     - January 2020 - Carbon, Davis, Salt Lake, Utah, Wasatch, Washington, Weber Counties

--- a/data/transportation/roads-system/index.html
+++ b/data/transportation/roads-system/index.html
@@ -87,7 +87,8 @@ abstract="This dataset contains GIS mapping data representing the statewide road
     </div>
     <div class="panel-content" id="RoadCenterlines-list">
       <ul class="dotless no-padding">
-        {% include downloads.html name="Utah Roads" item_id="478fbef62481427f95a3510a4707b24a" skip_shapefile=true %}
+        <li><a href="https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mcTQ0OG9oNThtWE0&export=download">Road Centerlines: File Geodatabase</a>
+        <li><a href="https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mU1M2VVIwU0tZVWs&export=download">Road Centerlines: Shapefile</a>
       </ul>
     </div>
   </div>
@@ -99,7 +100,7 @@ abstract="This dataset contains GIS mapping data representing the statewide road
     <div class="panel-content">
       <p>Updates to this dataset are published every month, with approximately nine counties receiving detailed review.</p>
       <ul class="dotless no-padding">
-        <li><a href="{% link _posts/2020-02-28-utah-sgid-statewide-roads-data-layer-updates-02282020.md %}">February 28, 2020</a>        
+        <li><a href="{% link _posts/2020-02-28-utah-sgid-statewide-roads-data-layer-updates-02282020.md %}">February 28, 2020</a>
         <li><a href="{% link _posts/2020-02-07-utah-sgid-statewide-roads-data-layer-updates-02072020.md %}">February 7, 2020</a>
         <li><a href="{% link _posts/2019-12-23-utah-sgid-statewide-roads-data-layer-updates-12232019.md %}">December 23, 2019</a>
         <li><a href="{% link _posts/2019-10-09-utah-sgid-statewide-roads-data-layer-updates-10092019.md %}">October 9, 2019</a>


### PR DESCRIPTION
This removes the open data links in favor of the back seat driven links that are being triggered by the global change detection project (cambiador). 

I am hearing the esri will update the download system in the next month so we can revert this commit when that happens to give the beta another shot.

closes #1357
