### PR TITLE
fix: status pages now carry the .app TLD

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -92,7 +92,7 @@
           <li class="menu-item{%- if current[1] == 'data' -%}{{ "active-2" | prepend: " " }}{%- endif -%}"><a href="{% link data/index.html %}">Data</a></li>
           <li class="menu-item{%- if current[1] == 'developer' -%}{{ "active-3" | prepend: " " }}{%- endif -%}"><a href="{% link developer/index.md %}">Developer</a></li>
           <li class="menu-item{%- if current[1] == 'about' -%}{{ "active-4" | prepend: " " }}{%- endif -%}"><a href="{% link about/index.md %}">About</a></li>
-          <li class="menu-item"><a href="https://agrc-status.netlify.com/">Status</a></li>
+          <li class="menu-item"><a href="https://agrc-status.netlify.app/">Status</a></li>
           <li class="menu-item"><a href="{% link search/index.html %}"><i class="fas fa-search" title="Site search link"></i></a></li>
         </ul>
       </nav>

--- a/_posts/2017-09-05-agrc-status.md
+++ b/_posts/2017-09-05-agrc-status.md
@@ -13,9 +13,9 @@ tags:
 
 Over the years, GIS is trending more and more towards being web-based. AGRC has tried to keep step with this trend with the addition of the [discover]({% link discover/index.html %}), the [TurnGPS]({% link data/cadastre/turn-gps/index.md %}) RTK GPS service, and the [Web API](https://api.mapserv.utah.gov) handling over one million requests per month. More and more users rely on these services. Outages are _very_ disruptive and we're doing everything in our power to avoid them. But in the event of a system outage we want our users to know **what** is going on, that you're not alone and that AGRC is aware of the issue, and **when** it is likely to be resolved.
 
-AGRC is now maintaining a system status website for the services we provide. Users can visit and bookmark [https://agrc-status.netlify.com](https://agrc-status.netlify.com) to check on the status of AGRC systems.
+AGRC is now maintaining a system status website for the services we provide. Users can visit and bookmark [https://agrc-status.netlify.app](https://agrc-status.netlify.app) to check on the status of AGRC systems.
 
-If you notice an outage, please check the [agrc status website](https://agrc-status.netlify.com) **first** as this will get you the details quickly and it leaves AGRC with more time to work toward resolution. If you do not see the status accurately reflected on the status page, please get in contact with us immediately by [phone or email]({% link about/contact/index.html %}) with a description of the problem.
+If you notice an outage, please check the [agrc status website](https://agrc-status.netlify.app) **first** as this will get you the details quickly and it leaves AGRC with more time to work toward resolution. If you do not see the status accurately reflected on the status page, please get in contact with us immediately by [phone or email]({% link about/contact/index.html %}) with a description of the problem.
 
 When outages occur, AGRC will use the status website to let users know that:
 


### PR DESCRIPTION
i can't find a blog post for the change but it happened