### PR TITLE
Hexagoncitation

### DIFF
--- a/about/policy/index.md
+++ b/about/policy/index.md
@@ -24,3 +24,8 @@ AGRC’s guidelines for creating, editing, maintaining, and removing data in the
 {: .text-left}
 
 AGRC’s guidelines for using the Open SGID database.
+
+#### [Licensed High-Resolution Imagery Citation]({% link discover/resources/index.md %}#citation-and-logos)
+{: .text-left}
+
+Citation requirements for high-resolution imagery licensed from Google and Hexagon.

--- a/discover/index.html
+++ b/discover/index.html
@@ -97,5 +97,5 @@ categories: []
 <ul>
   <li>We strongly recommended that you use WMTS for the best user experience.
   <li>If you are, or will be, printing base maps from the web and are experiencing blank or empty output, read about our <a href="{% link _posts/2017-02-02-printing-web-maps-with-discover-services.md %}">GP proxy service</a> or our new <a href="{% link _posts/2018-02-26-success-with-serverless.md %}">serverless print proxy</a>.
-  <li>Any end products using the licensed imagery must attribute Google or Hexagon. See the <a href="{% link discover/resources/index.md %}#google-logos">resources page</a> for logos.
+  <li>Any end products using the licensed imagery must attribute Google or Hexagon. See the <a href="{% link discover/resources/index.md %}#citation-and-logos">resources page</a> for logos.
 </ul>

--- a/discover/resources/index.md
+++ b/discover/resources/index.md
@@ -132,8 +132,9 @@ As part of our licenses with Google and Hexagon, you must provide proper attribu
 
 - **Google** requires you to put the appropriate logo [(zipfile)]({% link downloads/google_logos.zip %}) on any products made using the Google imagery (6" imagery earlier than 2018):
 
-    ![white transparent]({% link images/ImageryCGoogle_WhiteTransparent.png %})
-    ![white on black]({% link images/ImageryCGoogle_WhiteOnBlack.png %})
+  - ![white transparent]({% link images/ImageryCGoogle_WhiteTransparent.png %})
+  - ![white on black]({% link images/ImageryCGoogle_WhiteOnBlack.png %})
+  {: .dotless}
 
 For products that use the AGRC-produced basemaps, please include a short attribution that complies with the main [AGRC Data License and Disclaimer]({% link about/policy/license-disclaimer/index.md %}) guidelines.
 

--- a/discover/resources/index.md
+++ b/discover/resources/index.md
@@ -123,7 +123,7 @@ Individual organizations will be provided URL links for the Discover services th
 {: .text-left}
 
 <i class="fas fa-fw fa-lock"></i>
-Our licenses with Google and Hexagon require proper attribution of any products created with their imagery.
+As part of our licenses with Google and Hexagon, you must provide proper attribution of any products created with their imagery.
 
 - **Hexagon** requires the following attribution on any products made using the Hexagon imagery (15/30cm imagery 2018 and later):
 

--- a/discover/resources/index.md
+++ b/discover/resources/index.md
@@ -127,7 +127,8 @@ As part of our licenses with Google and Hexagon, you must provide proper attribu
 
 - **Hexagon** requires the following attribution on any products made using the Hexagon imagery (15/30cm imagery 2018 and later):
 
-    `© 2020 HxGN Content Program, Hexagon`
+  - Print: "© 2020 HxGN Content Program, Hexagon", with the year being the first year you published the product.
+  - Online: "© 2020 [HxGN Content Program](https://hxgncontent.com), Hexagon", with the year being the first year you published the product and the text `HxGN Content Program` linking to [https://hxgncontent.com](https://hxgncontent.com)
 
 - **Google** requires you to put the appropriate logo [(zipfile)]({% link downloads/google_logos.zip %}) on any products made using the Google imagery (6" imagery earlier than 2018):
 

--- a/discover/resources/index.md
+++ b/discover/resources/index.md
@@ -119,16 +119,20 @@ Users experiencing problems with the service, such as blurry tiles or different 
 
 Individual organizations will be provided URL links for the Discover services that are unique to their organization. This will allow us to track general usage metrics and monitor the performance of the services. Do not distribute your URL links outside of your organization or division.
 
-### Google Logos
+### Citation and Logos
 {: .text-left}
 
 <i class="fas fa-fw fa-lock"></i>
-Our license with Google requires you to put the appropriate logo on any products made using the Google imagery.
+Our licenses with Google and Hexagon require proper attribution of any products created with their imagery.
 
-[Download zipfile of Google logos]({% link downloads/google_logos.zip %})
+- **Hexagon** requires the following attribution on any products made using the Hexagon imagery (15/30cm imagery 2018 and later):
 
-![white transparent]({% link images/ImageryCGoogle_WhiteTransparent.png %})
-![white on black]({% link images/ImageryCGoogle_WhiteOnBlack.png %})
+    `© 2020 HxGN Content Program, Hexagon`
+
+- **Google** requires you to put the appropriate logo [(zipfile)]({% link downloads/google_logos.zip %}) on any products made using the Google imagery (6" imagery earlier than 2018):
+
+    ![white transparent]({% link images/ImageryCGoogle_WhiteTransparent.png %})
+    ![white on black]({% link images/ImageryCGoogle_WhiteOnBlack.png %})
 
 ### Requests for On-Premise Use
 {: .text-left}
@@ -137,11 +141,11 @@ Our license with Google requires you to put the appropriate logo on any products
 
 You may request a local copy of the NAIP, HRO, Hexagon, and Google imagery for off-line consumption when the provided imagery service does not meet your needs. {{ contact3 }} for consideration:
 
-- Name & organization:
-- Reason for request:
-- Working on behalf of:
-- Project names:
-- Project locations:
+- Name & organization
+- Reason for request
+- Working on behalf of (for licensed Hexagon/Google imagery)
+- Project names
+- Project locations
 
 ### Layers Not Exporting When Using WMS
 {: .text-left}

--- a/discover/resources/index.md
+++ b/discover/resources/index.md
@@ -134,6 +134,8 @@ As part of our licenses with Google and Hexagon, you must provide proper attribu
     ![white transparent]({% link images/ImageryCGoogle_WhiteTransparent.png %})
     ![white on black]({% link images/ImageryCGoogle_WhiteOnBlack.png %})
 
+For products that use the AGRC-produced basemaps, please include a short attribution that complies with the main [AGRC Data License and Disclaimer]({% link about/policy/license-disclaimer/index.md %}) guidelines.
+
 ### Requests for On-Premise Use
 {: .text-left}
 


### PR DESCRIPTION
Adding the proper Hexagon citation text per email from AppGeo and a quick line about attribution for AGRC-produced basemaps.

- Update text on Discover resources page.
- Update link on main Discover page.
- Add link from main AGRC policies page.

Also, some random formatting of the on-premise request text.