### PR TITLE
Update UGIC conference info

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ layout: default
   <div class="grid__col section action">
     <h1 id="spotlight">Utah Geographic Information Council Conference 2020</h1>
     <h3><strong>August 31 - September 4, 2020</strong></h3>
-    <p>The UGIC Board is pleased to announce that the 2020 conference will be held <strong>August 31 - September 4, 2020</strong> at the <strong>Ruby's Inn in Bryce Canyon, Utah</strong>. The board is working to make this the best UGIC conference yet! Save the date on your calendar, and stay tuned for more info in the coming weeks and months.</p> <a class="btn" href="http://events.r20.constantcontact.com/register/event?llr=arygxyiab&oeidk=a07eguwaasv0bb631d9">Register Now!</a>
+    <p>The UGIC Board is pleased to announce that the 2020 conference will be held <strong>August 31 - September 4, 2020</strong> <strong>as a virtual event</strong>. While this is certainly not a replacement for the conference itself, we hope to make it a fun and valuable experience for those who attend.  There will be no cost to attend the virtual event (all conference registrations will be refunded), and we will send out more details about it as our plans come together. For more details, check out the <a href="https://ugic.org/news/ugic-conference-rescheduled-faqs/">FAQ page</a></p>
   </div>
   <div class="grid__col section alternate">
     <a id="news" class="anchor"></a>


### PR DESCRIPTION
Update the info on the AGRC homepage to reflect UGIC being a virtual event instead of an in-person conference in the fall.

The UGIC FAQ page is here: https://ugic.org/news/ugic-conference-rescheduled-faqs/