### PR TITLE
point landownership data link to sgid opendata

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ Item:
   hub:
     name: ArcGIS Online name exactly eg Utah Address Points
     item_id: the item id
-    skip_shapefile: true or false optional
-    skip_fgdb: true or false optional
-    skip_hub: true or false optional
+    org: the sharing org name e.g. `SITLA`. When an org shares items it gets prefixed with their name e.g. `/SITLA::land-ownership`
+    skip_shapefile: true or false [optional]
+    skip_fgdb: true or false [optional]
+    skip_hub: true or false [optional]
 ```

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,4 +1,4 @@
-{% assign id = include.name | downcase | replace: ' ', '-' %}
+{% assign id = include.name | replace: ' ', '-' %}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,4 +1,4 @@
-{% assign id = include.name | replace: ' ', '-' %}
+{% assign id = include.name | downcase | replace: ' ', '-' %}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,5 +1,8 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
+{%- if include.org == nil or include.org == false -%}
+<li><a href="https://opendata.gis.utah.gov/datasets/{{ org | concat: "::" | id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
+{%- else -%}  
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}
 {%- if include.skip_fgdb == nil or include.skip_fgdb == false -%}

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,7 +1,7 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {% assign dataset_id = id %}
 {%- if include.org != nil or include.org != false -%}
-{%- assign dataset_id = {{ include.org | concat "::" | concat id }} -%}
+{%- assign dataset_id = {{ include.org }}::{{ id }} -%}
 {%- endif -%}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,6 +1,7 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
+{%- if include.org == nil or include.org == false -%}
 {% assign dataset_id = id %}
-{%- if include.org != nil or include.org != false -%}
+{%- else -%}
 {%- assign dataset_id = include.org | append: "::" | append: id -%}
 {%- endif -%}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -3,7 +3,7 @@
 {%- if include.org == nil or include.org == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- else -%}
-<li><a href="https://opendata.gis.utah.gov/datasets/{{ include.org | concat "::" | concat id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
+<li><a href="https://opendata.gis.utah.gov/datasets/{{ include.org }}::{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}
 {%- endif -%}
 {%- if include.skip_fgdb == nil or include.skip_fgdb == false -%}

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -3,7 +3,7 @@
 {%- if include.org == nil or include.org == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- else -%}
-<li><a href="https://opendata.gis.utah.gov/datasets/{{ include.org | concat: "::" | id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
+<li><a href="https://opendata.gis.utah.gov/datasets/{{ include.org | concat: "::" | concat: id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}
 {%- endif -%}
 {%- if include.skip_fgdb == nil or include.skip_fgdb == false -%}

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,7 +1,7 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {% assign dataset_id = id %}
 {%- if include.org != nil or include.org != false -%}
-{%- assign dataset_id = include.org :: id  -%}
+{%- assign dataset_id = include.org | "::" | id  -%}
 {%- endif -%}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,7 +1,7 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {% assign dataset_id = id %}
 {%- if include.org != nil or include.org != false -%}
-{%- dataset_id = {{ include.org }}::{{ id }} -%}
+{%- dataset_id = include.org :: id  -%}
 {%- endif -%}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,7 +1,7 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {% assign dataset_id = id %}
 {%- if include.org != nil or include.org != false -%}
-{%- assign dataset_id = include.org | "::" | id  -%}
+{%- assign dataset_id = {{ include.org | concat "::" | concat id }} -%}
 {%- endif -%}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,7 +1,7 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {% assign dataset_id = id %}
 {%- if include.org != nil or include.org != false -%}
-{%- assign dataset_id = {{ include.org }}::{{ id }} -%}
+{%- assign dataset_id = include.org | "::" | id -%}
 {%- endif -%}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,7 +1,7 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {% assign dataset_id = id %}
 {%- if include.org != nil or include.org != false -%}
-{%- assign dataset_id = include.org "::" id -%}
+{%- assign dataset_id = include.org | append: "::" | append: id -%}
 {%- endif -%}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -5,6 +5,7 @@
 {%- else -%}  
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}
+{%- endif -%}
 {%- if include.skip_fgdb == nil or include.skip_fgdb == false -%}
 <li><a href="https://opendata.arcgis.com/datasets/{{ include.item_id }}_0.gdb" id="{{ id }}-gdb">{{ include.name }}: File Geodatabase</a>
 {%- endif -%}

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,7 +1,7 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {% assign dataset_id = id %}
 {%- if include.org != nil or include.org != false -%}
-{%- assign dataset_id = include.org | "::" | id -%}
+{%- assign dataset_id = include.org "::" id -%}
 {%- endif -%}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -3,7 +3,7 @@
 {%- if include.org == nil or include.org == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- else -%}
-<li><a href="https://opendata.gis.utah.gov/datasets/{{ include.org | concat: "::" | concat: id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
+<li><a href="https://opendata.gis.utah.gov/datasets/{{ include.org | concat "::" | concat id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}
 {%- endif -%}
 {%- if include.skip_fgdb == nil or include.skip_fgdb == false -%}

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -3,7 +3,7 @@
 {%- if include.org == nil or include.org == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- else -%}
-<li><a href="https://opendata.gis.utah.gov/datasets/{{ org | concat: "::" | id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
+<li><a href="https://opendata.gis.utah.gov/datasets/{{ include.org | concat: "::" | id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}
 {%- endif -%}
 {%- if include.skip_fgdb == nil or include.skip_fgdb == false -%}

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,7 +1,7 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {% assign dataset_id = id %}
 {%- if include.org != nil or include.org != false -%}
-{%- dataset_id = include.org :: id  -%}
+{%- assign dataset_id = include.org :: id  -%}
 {%- endif -%}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,10 +1,10 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
-{%- if include.skip_hub == nil or include.skip_hub == false -%}
-{%- if include.org == nil or include.org == false -%}
-<li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
-{%- else -%}
-<li><a href="https://opendata.gis.utah.gov/datasets/{{ include.org }}::{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
+{% assign dataset_id = id %}
+{%- if include.org != nil or include.org != false -%}
+{%- dataset_id = {{ include.org }}::{{ id }} -%}
 {%- endif -%}
+{%- if include.skip_hub == nil or include.skip_hub == false -%}
+<li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}
 {%- if include.skip_fgdb == nil or include.skip_fgdb == false -%}
 <li><a href="https://opendata.arcgis.com/datasets/{{ include.item_id }}_0.gdb" id="{{ id }}-gdb">{{ include.name }}: File Geodatabase</a>

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,9 +1,9 @@
 {% assign id = include.name | downcase | replace: ' ', '-' %}
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 {%- if include.org == nil or include.org == false -%}
-<li><a href="https://opendata.gis.utah.gov/datasets/{{ org | concat: "::" | id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
-{%- else -%}  
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
+{%- else -%}
+<li><a href="https://opendata.gis.utah.gov/datasets/{{ org | concat: "::" | id }}" id="{{ id }}-hub">{{ include.name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}
 {%- endif -%}
 {%- if include.skip_fgdb == nil or include.skip_fgdb == false -%}

--- a/_includes/packagedata.html
+++ b/_includes/packagedata.html
@@ -11,7 +11,7 @@
         {%- endfor -%}
         {% endif %}
         {% if include.info.hub %}
-        {% include downloads.html name=include.info.hub.name item_id=include.info.hub.item_id %}
+        {% include downloads.html org=include.info.hub.org name=include.info.hub.name item_id=include.info.hub.item_id %}
         {% endif %}
         {% if include.info.opensgid %}
         {% include opensgid.html table=include.info.opensgid.table %}

--- a/data/cadastre/land-ownership/index.html
+++ b/data/cadastre/land-ownership/index.html
@@ -10,7 +10,7 @@ date: 2011-11-18 10:20:13 -0700
 categories: []
 LandOwnership:
   hub:
-    name: SITLA UT SITLA Ownership LandOwnership WM 1
+    name: SITLA:: UT SITLA Ownership LandOwnership WM 1
     item_id: 929fe39efa1d43ac8b151c2898ad3efe
   updates:
     - Weekly (Early Monday morning)

--- a/data/cadastre/land-ownership/index.html
+++ b/data/cadastre/land-ownership/index.html
@@ -10,7 +10,7 @@ date: 2011-11-18 10:20:13 -0700
 categories: []
 LandOwnership:
   hub:
-    name: Utah Land Ownership
+    name: SITLA UT SITLA Ownership LandOwnership WM 1
     item_id: 929fe39efa1d43ac8b151c2898ad3efe
   updates:
     - Weekly (Early Monday morning)

--- a/data/cadastre/land-ownership/index.html
+++ b/data/cadastre/land-ownership/index.html
@@ -9,9 +9,9 @@ author:
 date: 2011-11-18 10:20:13 -0700
 categories: []
 LandOwnership:
-  hub:
-    name: SITLA::UT SITLA Ownership LandOwnership WM 1
-    item_id: 929fe39efa1d43ac8b151c2898ad3efe
+  downloads:
+    -url: https://opendata.gis.utah.gov/datasets/SITLA::ut-sitla-ownership-landownership-wm-1
+     label: 'Land Ownership: Utah SITLA Open Data'
   updates:
     - Weekly (Early Monday morning)
 ---

--- a/data/cadastre/land-ownership/index.html
+++ b/data/cadastre/land-ownership/index.html
@@ -9,9 +9,9 @@ author:
 date: 2011-11-18 10:20:13 -0700
 categories: []
 LandOwnership:
-  downloads:
-    - url: https://data-sitla.opendata.arcgis.com/datasets/ut-sitla-ownership-landownership
-      label: 'Land Ownership: Utah SITLA Open Data'
+  hub:
+    name: Utah Land Ownership
+    item_id: 929fe39efa1d43ac8b151c2898ad3efe
   updates:
     - Weekly (Early Monday morning)
 ---
@@ -141,8 +141,7 @@ abstract=abstract %}
     <p><em>Examples: 9-Mile State Wildlife Area, Dead Horse Point State Park, State Trust Lands Book Cliffs Block, Whiterocks Fish Hatchery</em></p>
     <p><code>Shape_area</code> field is in square meters.</p>
   </div>
-  {% include packagedata.html name="LandOwnership"
-  info=page.LandOwnership %}
+  {% include packagedata.html name="LandOwnership" info=page.LandOwnership %}
 </div>
 <div class="grid package">
   <div class="grid__col grid__col--12-of-12">

--- a/data/cadastre/land-ownership/index.html
+++ b/data/cadastre/land-ownership/index.html
@@ -14,7 +14,7 @@ LandOwnership:
     name: UT SITLA Ownership LandOwnership WM 1
     item_id: 929fe39efa1d43ac8b151c2898ad3efe
   updates:
-    - Weekly (Early Monday morning)
+    - Daily
 ---
 <figure class="caption caption--right">
   <img class="caption__image" src="{% link images/LandOwnershipLarge2.png %}" alt="Land Ownership Map" />

--- a/data/cadastre/land-ownership/index.html
+++ b/data/cadastre/land-ownership/index.html
@@ -10,7 +10,7 @@ date: 2011-11-18 10:20:13 -0700
 categories: []
 LandOwnership:
   hub:
-    name: SITLA:: UT SITLA Ownership LandOwnership WM 1
+    name: SITLA::UT SITLA Ownership LandOwnership WM 1
     item_id: 929fe39efa1d43ac8b151c2898ad3efe
   updates:
     - Weekly (Early Monday morning)

--- a/data/cadastre/land-ownership/index.html
+++ b/data/cadastre/land-ownership/index.html
@@ -9,9 +9,10 @@ author:
 date: 2011-11-18 10:20:13 -0700
 categories: []
 LandOwnership:
-  downloads:
-    -url: https://opendata.gis.utah.gov/datasets/SITLA::ut-sitla-ownership-landownership-wm-1
-     label: 'Land Ownership: Utah SITLA Open Data'
+  hub:
+    org: SITLA::
+    name: UT SITLA Ownership LandOwnership WM 1
+    item_id: 929fe39efa1d43ac8b151c2898ad3efe
   updates:
     - Weekly (Early Monday morning)
 ---

--- a/data/cadastre/land-ownership/index.html
+++ b/data/cadastre/land-ownership/index.html
@@ -10,7 +10,7 @@ date: 2011-11-18 10:20:13 -0700
 categories: []
 LandOwnership:
   hub:
-    org: SITLA::
+    org: SITLA
     name: UT SITLA Ownership LandOwnership WM 1
     item_id: 929fe39efa1d43ac8b151c2898ad3efe
   updates:


### PR DESCRIPTION
i was able to work with SITLA and get their AGOL dataset exposed in SGID Open Data.  aka: the backend data on SGID Open Data is SITA's AGOL data.