### PR TITLE
fix: more explicit text for license link

### DIFF
--- a/discover/index.html
+++ b/discover/index.html
@@ -20,7 +20,7 @@ categories: []
 <p>You will need to register for a free Discover account to access these services. There are two levels of Discover access:</p>
 <ul class="dotless">
   <li><i class="far fa-fw fa-circle"></i> <strong>General access</strong>, for anyone who wants to use our base maps, NAIP imagery, or HRO imagery.</li>
-  <li><i class="fas fa-fw fa-lock"></i> <strong>Licensed access</strong>, for Utah's <strong>cities, counties, special districts, state agencies, K-12 school districts, colleges, universities, and tribal entities</strong> (or contractors or formal partners of any of these entities). This provides access to <strong>statewide high-resolution aerial imagery</strong> under the state's <a href="{% link discover/license/index.md %}">Google and Hexagon imagery licenses</a> in addition to the general base maps and imagery.</li>
+  <li><i class="fas fa-fw fa-lock"></i> <strong>Licensed access</strong>, for Utah's <strong>cities, counties, special districts, state agencies, K-12 school districts, colleges, universities, and tribal entities</strong> (or contractors or formal partners of any of these entities). This provides access to <strong>statewide high-resolution aerial imagery</strong> under the state's Google and Hexagon imagery licenses in addition to the general base maps and imagery. Visit the <a href="{% link discover/license/index.md %}">license information page</a> for more details.</li>
 </ul>
 <p class="pop text-center">
   <strong>Anyone</strong> can use the general access imagery and base map services from Discover! To use these services, all you need is a <strong><em>free</em></strong> account and its corresponding quad-word connection link.


### PR DESCRIPTION
I realized the link text for the license information page link could be slightly vague, so reworded to make explicit "click here for more info."