### PR TITLE
update roads page download links to opendata

### DIFF
--- a/data/transportation/roads-system/index.html
+++ b/data/transportation/roads-system/index.html
@@ -13,36 +13,28 @@ tags:
 categories: []
 date: 2011-08-25 23:12:40 -0600
 HighwayLinearReferencingSystemRoutes:
-  downloads:
-    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mSURhZHpJMDFnM1U&export=download
-      label: 'UDOT LRS Routes: File Geodatabase'
-    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mV2VRNTduVXNyMjg&export=download
-      label: 'UDOT LRS Routes: Shapefile'
+  hub:
+    name: Utah UDOT Routes LRS
+    item_id: cbc11cc11baf4160bc323fcb9384cc8a
   updates:
     - Updates to this dataset are published periodically to refine route representation,
       add additional routes, and in response to route realignment.
 MilepostPoints:
-  downloads:
-    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mb1BJT01oVEdOekU&export=download
-      label: 'Milepost Points: File Geodatabase'
-    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mNFlDenZWTnNwekE&export=download
-      label: 'Milepost Points: Shapefile'
+  hub:
+    name: Utah UDOT Mileposts
+    item_id: ba0d4dcd6d3b4c368a3f14fe09998df5
   updates:
     - Updates to this dataset are published periodically.
 TenthMileReferencePoints:
-  downloads:
-    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mTGhJNkxNcE9hVk0&export=download
-      label: 'Tenth of a Mile: File Geodatabase'
-    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mbVZ3bmVmLV9yemM&export=download
-      label: 'Tenth of a Mile: Shapefile'
+  hub:
+    name: Utah UDOT Tenth Mile Ref Points
+    item_id: 2b9972e0879248c2978da1c91d77ab4f
   updates:
     - Updates to this dataset are published periodically.
 FreewayExitPoints:
-  downloads:
-    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mNm1LNGN0eDNBLUE&export=download
-      label: 'Freeway Exit Points: File Geodatabase'
-    - url: https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mRjZpRFpkbng5ak0&export=download
-      label: 'Freeway Exit Points: Shapefile'
+  hub:
+    name: Utah Roads Freeway Exits
+    item_id: ead23cdea2184a45a92007261675457e
   updates:
     - Updates to this dataset are published infrequently.
 ShieldLabelingLines:
@@ -87,8 +79,6 @@ abstract="This dataset contains GIS mapping data representing the statewide road
     </div>
     <div class="panel-content" id="RoadCenterlines-list">
       <ul class="dotless no-padding">
-        <li><a href="https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mcTQ0OG9oNThtWE0&export=download">Road Centerlines: File Geodatabase</a>
-        <li><a href="https://drive.google.com/a/utah.gov/uc?id=0ByStJjVZ7c7mU1M2VVIwU0tZVWs&export=download">Road Centerlines: Shapefile</a>
         {% include downloads.html name="Utah Roads" item_id="478fbef62481427f95a3510a4707b24a" %}
       </ul>
     </div>


### PR DESCRIPTION
i'm leaving ShieldLabelingLines as a google drive download for now.  i moved the files to the agrc_public_share.  the data for this is not in arcgis online (open data) and probably shouldn't be.  i'm working on the backstory for this data.  it might be something we can remove.