### PR TITLE
Updates to SGID's Data >> Planning index page

### DIFF
--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -10,33 +10,83 @@ date: 2011-10-21 15:15:11 -0600
 title: Planning Overview
 categories: []
 ---
-{% include table_overview.html name="Planning" %}
+  <table>
+  <thead>  
+  <tr>
+      <th width "15%" scope="col">Subcategory</th>
+      <th width="25%" scope="col">Product Name</th>
+      <th scope="col">Type</th>
+      <th scope="col">Steward(s)</th>
+      <th width="40%" scope="col">Description</th>
+  </tr>
+  </thead>
+  <tfoot>
+    <tr>
+      <td colspan="4">
+        <em>click a product name for more information and download links</em>
+      </td>
+    </tr>
+  </tfoot>
+    
   <tbody>
     <tr>
-      <td><a href="{% link data/planning/water-related-land/index.html %}">Water Related Land Use</a></td>
+      <td>Aerial Photography</td>
+      <td><a href="{% link discover/license/index.md %}">Current High Res Aerial Photography</a></td>
+      <td>map data services</td>
+      <td>AGRC</td>
+      <td>The most current high resolution aerial photography for Utah is made available to GIS users (desktop and webapps) from AGRC's Discover server. This commerically-licensed imagery is available at no charge to state and local government (including tribes, k-12, and colleges), and their contractors and formal partners, for download and as high-performance web services.</td>
+    </tr>
+     <tr>
+      <td>Aerial Photography</td>
+      <td><a href="{% link data/aerial-photography %}">Archival Aerial Photography</a></td>
       <td>map data</td>
-      <td>DNR</td>
-      <td>Water usage-related polygon map data, published annually that depicts the types and extent of irrigated crops as well as information concerning phreatophytes, wet/open water areas, dry land agriculture and residential/industrial areas</td>
+      <td>AGRC & UGS</td>
+      <td>This link opens the AGRC aerial photography page with information on accessing older aerial photography including 1990's era DOQ's and older scanned aerial imagery </td>
+    </tr>
+     <tr>
+      <td>Base Maps</td>
+      <td><a href="{% link discover/#services %}">Base Maps</a></td>
+      <td>map data services</td>
+      <td>AGRC</td>
+      <td>AGRC's Discover server provides high-performance base maps -- built exclusively from GIS data in the State Geographic Information Database -- from its Discover server. Base map themes include terrain, lite, topographic, address points, and overlay. These are open to public use,, but require a free Discover account.</td>
     </tr>
     <tr>
+      <td>Boundaries</td>
+      <td><a href="{% link data/boundaries/citycountystate/index.html %}">City, County and State Boundaries</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Utah city (municipal), county, and state boundaries</td>
+    </tr>   
+    <tr>
+      <td>Cadastral</td>
+      <td><a href="{% link data/cadastre/parcels/index.html %}">Parcels</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Parcel boundaries and information</td>
+    </tr>
+    <tr>
+      <tdEnvironment</td>
       <td><a href="https://utah.maps.arcgis.com/home/item.html?id=2bc95f1947ad4efaa75672da9a3b79ea">Conservation Easements</a></td>
       <td>map data</td>
       <td>AGRC</td>
       <td>Conservation Easements in Utah.</td>
     </tr>
     <tr>
+      <td>Environment</td>
       <td><a href="{% link data/boundaries/conservation-districts/index.html %}">Conservation Districts and Zones</a></td>
       <td>map data</td>
       <td>AGRC</td>
       <td>Conservation Districts and Zones in Utah.</td>
     </tr>
     <tr>
+      <td>Environment</td>
       <td><a href="https://opendata.gis.utah.gov/datasets/utah-primitive-prop-emery-county">Primitive Areas</a></td>
       <td>map data</td>
       <td>AGRC</td>
       <td>Only in Emery County.</td>
     </tr>
     <tr>
+      <td>Environment</td>
       <td><a href="https://opendata.gis.utah.gov/datasets/utah-pli-areas-proposal-jan16">Public Lands Initiative Proposal PLI Areas</a> and 
       <a href="https://opendata.gis.utah.gov/datasets/utah-pli-lines-proposal-jan16">Public Lands Initiative Proposal PLI Lines</a></td>
       <td>map data</td>
@@ -44,22 +94,67 @@ categories: []
       <td>Features in these data were produced by the BLM for <a href="https://www.congress.gov/bill/114th-congress/house-bill/5780">HR 5780</a> to designate federal lands as wilderness and components of the National Wilderness Preservation System in Utah. <a href="http://www.utahpli.com/">The Public Lands Initiative (PLI)</a> is a locally-driven effort to bring resolution and certainty to some of the most challenging land disputes in Utah. The initiative is rooted in the belief that conservation and economic development can coexist and make Utah a better place to live, work, and visit.</td>
     </tr>
     <tr>
+      <td>Environment</td>
       <td><a href="https://opendata.gis.utah.gov/datasets/utah-urban-interface-areas">Urban Interface Areas</a></td>
       <td>map data</td>
       <td>AGRC</td>
       <td>Locations of Wildland Urban Interfaces.</td>
     </tr>
     <tr>
+      <td>Environment</td>
       <td><a href="{% link data/boundaries/wilderness/index.html %}"> Wilderness, Proposals & Protected Areas</a></td>
       <td>map data</td>
       <td>USFS/BLM</td>
       <td>Wilderness boundaries including BLM re-inventory and suitability, WSAs, roadless inventory and existing wilderness.</td>
     </tr>
     <tr>
+      <td>Environment</td>
       <td><a href="{% link data/water/wetlands/index.html %}">Wetlands</a></td>
       <td>map data</td>
       <td>USFWS</td>
       <td>Wetland areas in Utah.</td>
+    </tr>
+    <tr>
+      <td>Transportation</td>
+      <td><a href="{% link data/transportation/railroads/index.html %}">Railroads</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Statewide railroads data, including transit rail</td>
+    </tr>
+    <tr>
+      <td>Transportation</td>
+      <td><a href="{% link data/transportation/roads-system/index.html %}">Road and Highway System</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Statewide road and highway system data for cartography and address location. Includes local streets, mileposts, and numbered exit data.</td>
+    </tr>
+     <tr>
+      <td>Transportation</td>       
+      <td><a href="{% link data/transportation/street-network-analysis/index.html %}">Street Network Analysis</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Network datasets designed for routing, service areas, drive times, and distance analysis. Includes statewide street network dataset and Wasatch Front multimodal network dataset.</td>
+    </tr>
+    <tr>
+      <td>Transportation</td>      
+      <td><a href="{% link data/transportation/transit/index.html %}">Transit</a></td>
+      <td>map data</td>
+      <td>UTA</td>
+      <td>Routes and stops for buses, light rail and commuter rail</td>
+    </tr>
+    <tr>
+      <td>Transportation</td>
+      <td><a href="https://data-uplan.opendata.arcgis.com/" target="_blank" rel="noopener">UDOT Business System Data</a></td>
+      <td>data portal</td>
+      <td>UDOT</td>
+      <td>Utah Department of Transportation geospatial data and services gateway website. Includes detailed data for projects, pavement management, planning, medians, barriers, signs,traffic volume, lanes, etc available in various formats</td>
+    </tr>   
+    <tr>
+      <td>Water</td>
+      <td><a href="{% link data/planning/water-related-land/index.html %}">Water Related Land Use</a></td>
+      <td>map data</td>
+      <td>DNR</td>
+      <td>Water usage-related polygon map data, published annually that depicts the types and extent of irrigated crops as well as information concerning phreatophytes, wet/open water areas, dry land agriculture and residential/industrial areas</td>
     </tr>
   </tbody>
 </table>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -73,14 +73,14 @@ categories: []
     </tr>
      <tr>
       <td>Aerial Photography</td>
-      <td><a href="{% link data/aerial-photography %}">Archival Aerial Photography</a></td>
+      <td><a href="{% link data/aerial-photography/index.html %}">Archival Aerial Photography</a></td>
       <td>map data</td>
       <td>AGRC & UGS</td>
       <td>This link opens the AGRC aerial photography page with information on accessing older aerial photography including 1990's era DOQ's and older scanned aerial imagery </td>
     </tr>
      <tr>
       <td>Base Maps</td>
-      <td><a href="{% link discover/#services %}">Base Maps</a></td>
+      <td><a href="{% link discover/index.html/#services %}">Base Maps</a></td>
       <td>map data services</td>
       <td>AGRC</td>
       <td>AGRC's Discover server provides high-performance base maps -- built exclusively from GIS data in the State Geographic Information Database -- from its Discover server. Base map themes include terrain, lite, topographic, address points, and overlay. These are open to public use,, but require a free Discover account.</td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -80,7 +80,7 @@ categories: []
     </tr>
      <tr>
       <td>Base Maps</td>
-      <td><a href="{% link discover/index.html/#services %}">Base Maps</a></td>
+      <td><a href="{% link discover/index.html %}">Base Maps</a></td>
       <td>map data services</td>
       <td>AGRC</td>
       <td>AGRC's Discover server provides high-performance base maps -- built exclusively from GIS data in the State Geographic Information Database -- from its Discover server. Base map themes include terrain, lite, topographic, address points, and overlay. These are open to public use,, but require a free Discover account.</td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -157,7 +157,7 @@ categories: []
     </tr>
     <tr>
       <td>Destinations</td>
-      <td><a href="https://opendata.gis.utah.gov/datasets/utah-post-offices">Retail Centers</a></td>
+      <td><a href="https://data.wfrc.org/datasets/retail-centers">Retail Centers</a></td>
       <td>map data</td>
       <td>WFRC</td>
       <td>Locations of shopping malls and retail centers along the Wasatch Front.</td>
@@ -225,7 +225,14 @@ categories: []
       <td>map data</td>
       <td>Utah Dept of Health</td>
       <td>Obesity and physical activity rates by small health statistical areas</td>
-    </tr>       
+    </tr>
+     <tr>
+      <td>Housing</td>
+      <td><a href="https://data.wfrc.org/datasets/mobile-home-parks">Mobile Home Parks</a></td>
+      <td>map data</td>
+      <td>WFRC</td>
+      <td>Mobile Home parks in the Wasatch Front and Wasatch back areas (Davis, Morgan, Salt Lake, Summit, Tooele, Utah, Wasatch, Weber counties</td>
+    </tr>   
     <tr>
       <td>Land Use</td>
       <td><a href="{% link data/society/cemeteries/index.html %}">Cemeteries</a></td>
@@ -235,10 +242,10 @@ categories: []
     </tr>
     <tr>
       <td>Land Use</td>
-      <td><a href="{% link data/society/cemeteries/index.html %}">Wasatch Choice Urban Centers</a></td>
+      <td><a href="https://data.wfrc.org/datasets/generalized-future-land-use-2020">Generalized Future Land Use</a></td>
       <td>map data</td>
-      <td>WFRC/MAG</td>
-      <td>This dataset represents the regionally significant centers and other specialized land use from the Wasatch Choice 2050 Vision Map. Land use types in this dataset include four levels of centers (metropolitan, urban, city, neighborhood), employment districts, education districts, industrial districts, and special districts (airports, mining, military, etc.).</td>
+      <td>WFRC</td>
+      <td>A generalized interpretation (2020) of city and county general plans in the WFRC urban area. General plans present a community's aspirations for allowable future land use types and intensities.</td>
     </tr>    
     <tr>
       <td>Land Use</td>
@@ -255,12 +262,12 @@ categories: []
       <td>Locations of non state and non federal parks.</td>
     </tr> 
     <tr>
-      <td>Transportation</td>
-      <td><a href="{% link data/transportation/railroads/index.html %}">Railroads</a></td>
+      <td>Land Use</td>
+      <td><a href="https://data.wfrc.org/datasets/wasatch-choice-2050-centers-vision-map">Wasatch Choice Urban Centers</a></td>
       <td>map data</td>
-      <td>AGRC</td>
-      <td>Statewide railroads data, including transit rail</td>
-    </tr>
+      <td>WFRC/MAG</td>
+      <td>This dataset represents the regionally significant centers and other specialized land use from the Wasatch Choice 2050 Vision Map. Land use types in this dataset include four levels of centers (metropolitan, urban, city, neighborhood), employment districts, education districts, industrial districts, and special districts (airports, mining, military, etc.).</td>
+    </tr>      
     <tr>
       <td>Transportation</td>
       <td><a href="https://data.wfrc.org/datasets/utah-statewide-traffic-volume-historic-and-forecast">Annual Average Daily Traffic (AADT), Historic & Forecasted</a></td>
@@ -277,11 +284,32 @@ categories: []
     </tr>
     <tr>
       <td>Transportation</td>
-      <td><a href="{% link data/recreation/trails/index.html %}">Pathwyas, Trails, and Trailheads</a></td>
+      <td><a href="https://data.wfrc.org/datasets/average-taz-commute-times">Average Commute Times/a></td>
+      <td>map data</td>
+      <td>WFRC/MAG</td>
+      <td>Projected average auto and transit commute times (one way) for residents of Wasatch Front traffic analysis zones (TAZs) for 2019, 2030, 2040, & 2040</td>
+    </tr>
+    <tr>
+      <td>Transportation</td>
+      <td><a href="https://data.wfrc.org/datasets/sb34-major-transit-investment-corridors">Major Transit Investment Corridors (per SB34)</a></td>
+      <td>map data</td>
+      <td>WFRC</td>
+      <td>This dataset identifies transit service routes that meet the definition within Senate Bill 34 (line 858), passed during the Utah Legislature's 2019 General Session</td>
+    </tr>   
+    <tr>
+      <td>Transportation</td>
+      <td><a href="{% link data/recreation/trails/index.html %}">Pathways, Trails, and Trailheads</a></td>
       <td>map data</td>
       <td>AGRC</td>
       <td>Established trails and trailheads in Utah.</td>
     </tr>   
+    <tr>
+      <td>Transportation</td>
+      <td><a href="{% link data/transportation/railroads/index.html %}">Railroads</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Statewide railroads data, including transit rail</td>
+    </tr>
     <tr>
       <td>Transportation</td>
       <td><a href="{% link data/transportation/roads-system/index.html %}">Road and Highway System</a></td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -80,7 +80,7 @@ categories: []
     </tr>
      <tr>
       <td>Base Maps</td>
-      <td><a href="{% link discover/index.html#services %}">Base Maps</a></td>
+      <td><a href="{% link discover/index.html %}">Base Maps</a></td>
       <td>map data services</td>
       <td>AGRC</td>
       <td>AGRC's Discover server provides high-performance base maps -- built exclusively from GIS data in the State Geographic Information Database -- from its Discover server. Base map themes include terrain, lite, topographic, address points, and overlay. These are open to public use,, but require a free Discover account.</td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -105,7 +105,70 @@ categories: []
       <td>map data</td>
       <td>WFRC, MAG, Cache MPO, Dixie MPO, UDOT</td>
       <td>Forecasted population, household, and job counts, annually from 2015-2050, at the Traffic Analysis Zone (TAZ) and 'City Area' levels. These dataset was developed for the purpose of transportation modeling and conforms with the county-level population projections developed by GPI for the Utah Population Committee. Utah has 8745 TAZ's statewide, 2871 of which are within the Wasatch Front urban modeling area. 'City Areas' are combinations of TAZ that approximate current city boundaries</td>
+    </tr>
+    <tr>
+      <td>Demographic</td>
+      <td><a href="{% link data/demographic/projections/index.html %}">Equity Focus Areas (WFRC Area)</a></td>
+      <td>map data</td>
+      <td>WFRC</td>
+      <td>WFRC has adopted an Equity Focus Area (EFA)framework as an input to its transportation planning efforts. EFAs are census block groups where any of the following criteria is met: > 25% low income, > 40% Persons of Color, OR > 10% zero car housholds</td>
+    </tr>
+    <tr>
+      <td>Destinations</td>
+      <td><a href="https://data.wfrc.org/datasets/community-centers">Community Centers</a></td>
+      <td>map data</td>
+      <td>WFRC</td>
+      <td>Recreation centers, libraries, and other community recreation facilities along the Wasatch Front</td>
+    </tr> 
+    <tr>
+      <td>Destinations</td>
+      <td><a href="https://data.wfrc.org/datasets/community-services">Community Services</a></td>
+      <td>map data</td>
+      <td>WFRC/UDAF</td>
+      <td>Community services along the Wasatch Front including city halls, county offices, courthouses, food banks, human services, the state capitol, vehicle services, and workforce services. Locations were primarily derived from digitizing or geocoding office locations listed on various state and nonprofit websites (DMV, Utah Food Bank, DWS)</td>
+    </tr>     
+    <tr>
+      <td>Destinations</td>
+      <td><a href="https://data.wfrc.org/datasets/utah-grocery-and-food-stores-udaf">Grocery Stores</a></td>
+      <td>map data</td>
+      <td>WFRC/UDAF</td>
+      <td>Grocery Stores and other food stores from the Utah Department of Agriculture and Food (UDAF) database (2018). Use the 'TYPE' field to filter by type of store.</td>
+    </tr> 
+    <tr>
+      <td>Destinations</td>
+      <td><a href="https://data.wfrc.org/datasets/utah-child-care-centers">Child Care Facilities</a></td>
+      <td>map data</td>
+      <td>WFRC/HIFLD</td>
+      <td>Child care and preschool facilities from the US DHS HIFLD open data site.</td>
+    </tr>
+    <tr>
+      <td>Destinations</td>
+      <td><a href="{% link data/health/health-care-facilities/index.html %}">Healthcare Facilities</a></td>
+      <td>map data</td>
+      <td>AGRC, Utah Department of Health, Division of Emergency Management</td>
+      <td>Healthcare Facilities and Emergency Medical Service (EMS) locations in Utah</td>
+    </tr>
+    <tr>
+      <td>Destinations</td>
+      <td><a href="https://opendata.gis.utah.gov/datasets/utah-post-offices">Post Offices</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Locations of Utah Post Offices according to an address list from the Salt Lake City USPS District Office.</td>
+    </tr>
+    <tr>
+      <td>Destinations</td>
+      <td><a href="https://opendata.gis.utah.gov/datasets/utah-post-offices">Retail Centers</a></td>
+      <td>map data</td>
+      <td>WFRC</td>
+      <td>Locations of shopping malls and retail centers along the Wasatch Front.</td>
     </tr>    
+    <tr>
+      <td>Destinations</td>
+      <td><a href="{% link data/society/schools-libraries/index.html %}">Schools & Libraries</td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Locations and information for schools and libraries in Utah.</td>
+    </tr>
     <tr>
       <td>Environment</td>
       <td><a href="https://utah.maps.arcgis.com/home/item.html?id=2bc95f1947ad4efaa75672da9a3b79ea">Conservation Easements</a></td>
@@ -156,6 +219,41 @@ categories: []
       <td>USFWS</td>
       <td>Wetland areas in Utah.</td>
     </tr>
+     <tr>
+      <td>Health</td>
+      <td><a href="https://opendata.gis.utah.gov/datasets/utah-health-small-statistical-areas-obesity-and-activity">Health Indicators</a></td>
+      <td>map data</td>
+      <td>Utah Dept of Health</td>
+      <td>Obesity and physical activity rates by small health statistical areas</td>
+    </tr>       
+    <tr>
+      <td>Land Use</td>
+      <td><a href="{% link data/society/cemeteries/index.html %}">Cemeteries</a></td>
+      <td>map data</td>
+      <td>Utah State History</td>
+      <td>Cemetery locations in Utah.</td>
+    </tr>
+    <tr>
+      <td>Land Use</td>
+      <td><a href="{% link data/society/cemeteries/index.html %}">Wasatch Choice Urban Centers</a></td>
+      <td>map data</td>
+      <td>WFRC/MAG</td>
+      <td>This dataset represents the regionally significant centers and other specialized land use from the Wasatch Choice 2050 Vision Map. Land use types in this dataset include four levels of centers (metropolitan, urban, city, neighborhood), employment districts, education districts, industrial districts, and special districts (airports, mining, military, etc.).</td>
+    </tr>    
+    <tr>
+      <td>Land Use</td>
+      <td><a href="{% link data/recreation/golf-courses/index.html %}">Golf Courses</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Locations of Municipal, Private, Public and Resort Golf Courses.</td>
+    </tr>
+    <tr>
+      <td>Land Use</td>
+      <td><a href="{% link data/recreation/local-parks/index.html %}">Local Parks</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Locations of non state and non federal parks.</td>
+    </tr> 
     <tr>
       <td>Transportation</td>
       <td><a href="{% link data/transportation/railroads/index.html %}">Railroads</a></td>
@@ -179,6 +277,13 @@ categories: []
     </tr>
     <tr>
       <td>Transportation</td>
+      <td><a href="{% link data/recreation/trails/index.html %}">Pathwyas, Trails, and Trailheads</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Established trails and trailheads in Utah.</td>
+    </tr>   
+    <tr>
+      <td>Transportation</td>
       <td><a href="{% link data/transportation/roads-system/index.html %}">Road and Highway System</a></td>
       <td>map data</td>
       <td>AGRC</td>
@@ -193,7 +298,7 @@ categories: []
     </tr>
     <tr>
       <td>Transportation</td>      
-      <td><a href="{% link data/transportation/transit/index.html %}">Transit</a></td>
+      <td><a href="{% link data/transportation/transit/index.html %}">Transit Routes, Stations, and Stops</a></td>
       <td>map data</td>
       <td>UTA</td>
       <td>Routes and stops for buses, light rail and commuter rail</td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -80,7 +80,7 @@ categories: []
     </tr>
      <tr>
       <td>Base Maps</td>
-      <td><a href="{% link discover/index.html %}">Base Maps</a></td>
+      <td><a href="{% link discover/index.html#services %}">Base Maps</a></td>
       <td>map data services</td>
       <td>AGRC</td>
       <td>AGRC's Discover server provides high-performance base maps -- built exclusively from GIS data in the State Geographic Information Database -- from its Discover server. Base map themes include terrain, lite, topographic, address points, and overlay. These are open to public use,, but require a free Discover account.</td>
@@ -337,6 +337,21 @@ categories: []
       <td>data portal</td>
       <td>UDOT</td>
       <td>Utah Department of Transportation geospatial data and services gateway website. Includes detailed data for projects, pavement management, planning, medians, barriers, signs,traffic volume, lanes, etc available in various formats</td>
+    </tr>
+    
+    <tr>
+      <td>Transportation</td>
+      <td><a href="https://data-rideuta.opendata.arcgis.com/search?tags=UTA_SERVICE_DATA">Utah Transit Authority (UTA) Open Data Site</a></td>
+      <td>data portal</td>
+      <td>UTA</td>
+      <td>Utah Transit Authority (UTA) geospatial data and services gateway website. Includes stop/station, route, and mode-level boarding counts.</td>
+    </tr>    
+    <tr>
+      <td>Transportation</td>
+      <td><a href="https://rideuta.maps.arcgis.com/apps/opsdashboard/index.html#/43fc692872714c418a83343f481c2e99">Utah Transit Authority (UTA) Ridership Dashboard</a></td>
+      <td>dashboard</td>
+      <td>UTA</td>
+      <td>Utah Transit Authority (UTA) ridership dashboard, includes views of Commuter Rail, Light Rail, Streetcar, Regular Bus, Express Bus, Ski Bus, BRT Bus (UVX), Vanpool, and Paratransit modes</td>
     </tr>   
     <tr>
       <td>Water</td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -69,7 +69,7 @@ categories: []
       <td><a href="{% link discover/license/index.md %}">Current High Res Aerial Photography</a></td>
       <td>map data services</td>
       <td>AGRC</td>
-      <td>The most current high resolution aerial photography for Utah is made available to GIS users (desktop and webapps) from AGRC's Discover server. This commerically-licensed imagery is available at no charge to state and local government (including tribes, k-12, and colleges), and their contractors and formal partners, for download and as high-performance web services.</td>
+      <td>The most current high resolution aerial photography for Utah is made available to GIS users (desktop and webapps) from AGRC's Discover server. This commercially-licensed imagery is available at no charge to state and local government (including tribes, k-12, and colleges), and their contractors and formal partners, for download and as high-performance web services.</td>
     </tr>
      <tr>
       <td>Aerial Photography</td>
@@ -108,10 +108,10 @@ categories: []
     </tr>
     <tr>
       <td>Demographic</td>
-      <td><a href="{% link data/demographic/projections/index.html %}">Equity Focus Areas (WFRC Area)</a></td>
+      <td><a href="https://data.wfrc.org/datasets/equity-focus-areas/data">Equity Focus Areas (WFRC Area)</a></td>
       <td>map data</td>
       <td>WFRC</td>
-      <td>WFRC has adopted an Equity Focus Area (EFA)framework as an input to its transportation planning efforts. EFAs are census block groups where any of the following criteria is met: > 25% low income, > 40% Persons of Color, OR > 10% zero car housholds</td>
+      <td>WFRC has adopted an Equity Focus Area (EFA)framework as an input to its transportation planning efforts. EFAs are census block groups where any of the following criteria is met: > 25% low income, > 40% Persons of Color, OR > 10% zero car households</td>
     </tr>
     <tr>
       <td>Destinations</td>
@@ -196,7 +196,7 @@ categories: []
       <a href="https://opendata.gis.utah.gov/datasets/utah-pli-lines-proposal-jan16">Public Lands Initiative Proposal PLI Lines</a></td>
       <td>map data</td>
       <td>BLM</td>
-      <td>Features in these data were produced by the BLM for <a href="https://www.congress.gov/bill/114th-congress/house-bill/5780">HR 5780</a> to designate federal lands as wilderness and components of the National Wilderness Preservation System in Utah. <a href="http://www.utahpli.com/">The Public Lands Initiative (PLI)</a> is a locally-driven effort to bring resolution and certainty to some of the most challenging land disputes in Utah. The initiative is rooted in the belief that conservation and economic development can coexist and make Utah a better place to live, work, and visit.</td>
+      <td>Features in these data were produced by the BLM for <a href="https://www.congress.gov/bill/114th-congress/house-bill/5780">HR 5780</a> to designate federal lands as wilderness and components of the National Wilderness Preservation System in Utah. <a href="http://www.utahpli.com/">The Public Lands Initiative (PLI)</a> is a locally-driven effort to bring resolution and certainty to some of the most challenging land disputes in Utah.</td>
     </tr>
     <tr>
       <td>Environment</td>
@@ -284,7 +284,7 @@ categories: []
     </tr>
     <tr>
       <td>Transportation</td>
-      <td><a href="https://data.wfrc.org/datasets/average-taz-commute-times">Average Commute Times/a></td>
+      <td><a href="https://data.wfrc.org/datasets/average-taz-commute-times">Average Commute Times</a></td>
       <td>map data</td>
       <td>WFRC/MAG</td>
       <td>Projected average auto and transit commute times (one way) for residents of Wasatch Front traffic analysis zones (TAZs) for 2019, 2030, 2040, & 2040</td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -79,7 +79,7 @@ categories: []
       <td>Parcel boundaries and characteristics from Utah's County Recorders ("Basic" parcels) and County Assessors ("LIR" tax parcels -- includes valuation, property types, tax exemption, and improvement characteristics)</td>
     </tr>
     <tr>
-      <td>Demographic</td>
+      <td>Demographic (Socioeconomic)</td>
       <td><a href="{% link data/demographic/projections/index.html %}">Population and Employment Projections (TAZ-level)</a></td>
       <td>map data</td>
       <td>WFRC, MAG, Cache MPO, Dixie MPO, UDOT</td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -23,12 +23,26 @@ categories: []
   <tfoot>
     <tr>
       <td colspan="4">
-        <em>click a product name for more information and download links</em>
+        <em>click a product name for more information and/or download links</em>
       </td>
     </tr>
   </tfoot>
     
   <tbody>
+    <tr>
+      <td>Accessibility</td>
+      <td><a href="https://data.wfrc.org/datasets/access-to-opportunities-work-related-taz-based">Workplace Accessibility</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Workplace Access to Opportunities (ATO) metrics for typical peak period auto and transit commutes, at the Traffic Analysis Zone (TAZ) level. Includes measures for household (access to jobs) and employer (access to workers/customers) perspectives. These datasets use a 'distance decay' travel cost weighting based on typical Wasatch Front commuting and are designed to take the place of "jobs within x minutes" datasets. This extent of this dataset currently is the Wasatch Front urban area although this will soon be expanded statewide. <a href="https://wfrc.org/ato"> More info on ATO</a></td>
+    </tr>  
+    <tr>
+      <td>Accessibility</td>
+      <td><a href="https://data.wfrc.org/datasets/commute-source-intensity">Household and Employment Intensity</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>A quick summary of residential and employment intensity within ~1/4 mile for city-block-sized polygons in the Wasatch Front urban areas. This roughly represents commuter trip producing and attracting areas. <a href="https://wfrc.org/ato"> More info on ATO</a></td>
+    </tr> 
     <tr>
       <td>Aerial Photography</td>
       <td><a href="{% link discover/license/index.md %}">Current High Res Aerial Photography</a></td>
@@ -58,12 +72,19 @@ categories: []
       <td>Utah city (municipal), county, and state boundaries</td>
     </tr>   
     <tr>
-      <td>Cadastral</td>
+      <td>Cadastral (Land Ownership)</td>
       <td><a href="{% link data/cadastre/parcels/index.html %}">Parcels</a></td>
       <td>map data</td>
       <td>AGRC</td>
-      <td>Parcel boundaries and information</td>
+      <td>Parcel boundaries and characteristics from Utah's County Recorders ("Basic" parcels) and County Assessors ("LIR" tax parcels -- includes valuation, property types, tax exemption, and improvement characteristics)</td>
     </tr>
+    <tr>
+      <td>Demographic</td>
+      <td><a href="{% link data/demographic/projections/index.html %}">Population and Employment Projections (TAZ-level)</a></td>
+      <td>map data</td>
+      <td>WFRC, MAG, Cache MPO, Dixie MPO, UDOT</td>
+      <td>Forecasted population, household, and job counts, annually from 2015-2050, at the Traffic Analysis Zone (TAZ) and 'City Area' levels. These dataset was developed for the purpose of transportation modeling and conforms with the county-level population projections developed by GPI for the Utah Population Committee. Utah has 8745 TAZ's statewide, 2871 of which are within the Wasatch Front urban modeling area. 'City Areas' are combinations of TAZ that approximate current city boundaries</td>
+    </tr>    
     <tr>
       <tdEnvironment</td>
       <td><a href="https://utah.maps.arcgis.com/home/item.html?id=2bc95f1947ad4efaa75672da9a3b79ea">Conservation Easements</a></td>
@@ -120,6 +141,20 @@ categories: []
       <td>map data</td>
       <td>AGRC</td>
       <td>Statewide railroads data, including transit rail</td>
+    </tr>
+    <tr>
+      <td>Transportation</td>
+      <td><a href="https://data.wfrc.org/datasets/utah-statewide-traffic-volume-historic-and-forecast">Annual Average Daily Traffic (AADT), Historic & Forecasted</a></td>
+      <td>map data</td>
+      <td>WFRC, MAG, Cache MPO, Dixie MPO, UDOT</td>
+      <td>This statewide traffic volume GIS dataset contains observed (historic, from UDOT) and forecasted traffic volumes (from MPOs and UDOT) on highways and major roads.</td>
+    </tr> 
+    <tr>
+      <td>Transportation</td>
+      <td><a href="https://wfrc.org/traffic-volume-map/">Annual Average Daily Traffic (AADT), Historic & Forecasted</a></td>
+      <td>webmap</td>
+      <td>WFRC, MAG, Cache MPO, Dixie MPO, UDOT</td>
+      <td>This statewide traffic volume viewer shows observed (historic, from UDOT) and forecasted traffic volumes (from MPOs and UDOT) on highways and major roads. The advanced tab allows for traffic volumes to be seen in the context of forecasted population, employment, and future regional transportation projects.</td>
     </tr>
     <tr>
       <td>Transportation</td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -44,6 +44,27 @@ categories: []
       <td>A quick summary of residential and employment intensity within ~1/4 mile for city-block-sized polygons in the Wasatch Front urban areas. This roughly represents commuter trip producing and attracting areas. <a href="https://wfrc.org/ato"> More info on ATO</a></td>
     </tr> 
     <tr>
+      <td>Active Transportation</td>
+      <td><a href="{% link data/transportation/roads-system/index.html %}">On-Street Bike Facilities</a></td>
+      <td>map data</td>
+      <td>AGRC, WFRC, MAG</td>
+      <td>Existing and planned bicycle infrastructure on/near roadways (bike lanes, cycle tracks, bike boulevards etc.), is coded on the road centerline dataset using Bike_L(eft), Bike_R(ight), Bike_Plan_L, Bike_Pln_R attributes. The Bike_RegPr field is used to distinguish regional bike facilities from more locally oriented facilities. This dataset is populated based on local data and local plans compiled by WFRC & MAG, and 2019 aerial photography review by UDOT Traffic and Safety. See Trails and Pathways for non-road bike/ped facilities.</td>
+    </tr>
+    <tr>
+      <td>Active Transportation</td>
+      <td><a href="{% link data/recreation/trails/ %}">Trails and Pathways (Bike/Ped/Hike)</a></td>
+      <td>map data</td>
+      <td>AGRC</td>
+      <td>Existing and planned trails and pathways (off-street), statewide. The Status field differentiates planned from existing and Carto_Code and Class differentiate different types of trails and pathways. See On-Street Bike Facilities for bike lanes, cycle tracks, etc.</td>
+    </tr>    
+    <tr>
+      <td>Active Transportation</td>
+      <td><a href="{% link data/transportation/roads-system/index.html %}">Road and Highway System</a></td>
+      <td>map data</td>
+      <td>AGRC, WFRC, MAG</td>
+      <td>Existing and planned bicycle infrastructure on/near roadways is coded on the road centerline dataset using Bike_L(eft), Bike_R(ight), Bike_Plan_L, Bike_Pln_R attributes. The Bike_RegPr field is used to distinguish regional bike facilities from more locally oriented facilities. This dataset is populated based on local data and local plans compiled by WFRC & MAG, and 2019 aerial photography review by UDOT Traffic and Safety.</td>
+    </tr>    
+    <tr>
       <td>Aerial Photography</td>
       <td><a href="{% link discover/license/index.md %}">Current High Res Aerial Photography</a></td>
       <td>map data services</td>
@@ -86,7 +107,7 @@ categories: []
       <td>Forecasted population, household, and job counts, annually from 2015-2050, at the Traffic Analysis Zone (TAZ) and 'City Area' levels. These dataset was developed for the purpose of transportation modeling and conforms with the county-level population projections developed by GPI for the Utah Population Committee. Utah has 8745 TAZ's statewide, 2871 of which are within the Wasatch Front urban modeling area. 'City Areas' are combinations of TAZ that approximate current city boundaries</td>
     </tr>    
     <tr>
-      <tdEnvironment</td>
+      <td>Environment</td>
       <td><a href="https://utah.maps.arcgis.com/home/item.html?id=2bc95f1947ad4efaa75672da9a3b79ea">Conservation Easements</a></td>
       <td>map data</td>
       <td>AGRC</td>

--- a/data/planning/index.html
+++ b/data/planning/index.html
@@ -52,7 +52,7 @@ categories: []
     </tr>
     <tr>
       <td>Active Transportation</td>
-      <td><a href="{% link data/recreation/trails/ %}">Trails and Pathways (Bike/Ped/Hike)</a></td>
+      <td><a href="{% link data/recreation/trails/index.html %}">Trails and Pathways (Bike/Ped/Hike)</a></td>
       <td>map data</td>
       <td>AGRC</td>
       <td>Existing and planned trails and pathways (off-street), statewide. The Status field differentiates planned from existing and Carto_Code and Class differentiate different types of trails and pathways. See On-Street Bike Facilities for bike lanes, cycle tracks, etc.</td>


### PR DESCRIPTION
The SGID Planning category was always a last resort for data that didn't fit neatly into other categories. 

The updates in this PR are a first crack at expanding this index page greatly to be a data resource guide for transportation, land use, and economic development planning. The idea to do this arose out of several planning working groups as it was felt that too often data resources were not well known when starting planning projects and studies. Several locations were considered but since this page is currently the top search result for "planning data utah", it was identified as the place to start.

It is expected that this update page and its contents will be shared within several professional planning circles, including UDOT, MPOs, and the Utah Chapter of the American Planning Association. An invitation will accompany this distribution to suggesting additional resources to be added to this index page.