### PR TITLE
fix: remove extra padding to nested lists

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -161,6 +161,8 @@ a:hover > i {
 
     ul, ol {
         padding-left: 40px;
+    }
+    ul:not(li ul), ol:not(li ul) {
         margin-bottom: 1em;
     }
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1326248/106671668-164dc180-656c-11eb-8ba0-5e98a03de8d7.png)

After:
![image](https://user-images.githubusercontent.com/1326248/106671675-18b01b80-656c-11eb-8af9-3039fa9e2750.png)
