### PR TITLE
feat: add privacy policy link to policies page

### DIFF
--- a/about/policy/index.md
+++ b/about/policy/index.md
@@ -41,3 +41,8 @@ UGRC’s policy for creating, editing, maintaining, and removing data in the SGI
 {: .text-left}
 
 UGRC’s metadata guidelines for data in the SGID database.
+
+#### [State of Utah Privacy Policy](https://www.utah.gov/support/privacypolicy.html)
+{: .text-left}
+
+[gis.utah.gov]({% link index.html %}) follows the state's master Privacy Policy.


### PR DESCRIPTION
The privacy policy link is on the utah.gov-provided footer at the very bottom of every page, but it may not hurt to add it to our policies page as well.