### PR TITLE
replace Li DAR with Lidar

### DIFF
--- a/data/sgid-index/index.html
+++ b/data/sgid-index/index.html
@@ -2521,7 +2521,7 @@ Horizontal_Positional_Accuracy: GPS = geocode or aerial imagery placement; Asser
             </tr>
             <tr>
                 <td data-th="category" class="category">indices</td>
-                <td data-th="name" class="name"><a href="{% link data/indices/lidar-extents/index.html %}">Li DAR Extents</a></td>
+                <td data-th="name" class="name"><a href="{% link data/indices/lidar-extents/index.html %}">Lidar Extents</a></td>
                 <td data-th="agency" class="agency">UGRC</td>
                 <td data-th="description" class="description">Lidar elevation data coverage</td>
                 <td data-th="service" class="service"><a href="https://opendata.gis.utah.gov/datasets/utah-lidar-extents" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
@@ -3272,7 +3272,8 @@ Horizontal_Positional_Accuracy: GPS = geocode or aerial imagery placement; Asser
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/search?q=aadt">AADT</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Average Annual Daily Traffic (AADT)  on road sections of the State
+                <td data-th="description" class="description">Average Annual Daily Traffic (AADT)  on road sections of the State
+
 Highways or Local Federal-Aid roads</td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3301,8 +3302,10 @@ Highways or Local Federal-Aid roads</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/826cbe57fd584889b88f4969af587e26_0">ATR Locations</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">UDOT has automatic traffic recorder (ATR) stations located
-throughout the state. These stations are placed on various
+                <td data-th="description" class="description">UDOT has automatic traffic recorder (ATR) stations located
+
+throughout the state. These stations are placed on various
+
 types of highway systems</td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3310,9 +3313,12 @@ types of highway systems</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/ea5705c27e274f29b82015309363b0ab_0">Barriers</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">This dataset contains barriers located along Utah state
-highways. Descriptive information includes barrier type,
-height, offset from roadway, post type, and end treatment
+                <td data-th="description" class="description">This dataset contains barriers located along Utah state
+
+highways. Descriptive information includes barrier type,
+
+height, offset from roadway, post type, and end treatment
+
 types. Location information includes x,y and route & milepost.</td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FI_Barriers/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3320,7 +3326,8 @@ types. Location information includes x,y and route & milepost.</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/9df4865bcb1a4f86b7a8afa43a34b3d0_0">Bike Lanes</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Bike Lane locations along state routes. This file indicates
+                <td data-th="description" class="description">Bike Lane locations along state routes. This file indicates
+
 where a bike lane with paint striping is present only</td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FI_BikeLanes/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3328,7 +3335,8 @@ where a bike lane with paint striping is present only</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/a3ef645a46584390846f0445a83959d4_0">Cattle Guard Inventory</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Cattle guard inventory data comes from the Operations
+                <td data-th="description" class="description">Cattle guard inventory data comes from the Operations
+
 Management System (OMS)</td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/CattleguardInventoryOMS/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3350,8 +3358,10 @@ Management System (OMS)</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/a7ee5e6cc85742978d25449aae6c1941_0">EPM Projects</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Project data from ePM (Electronic Project Management). This
-service contains point, line and polygon layers for UDOT's
+                <td data-th="description" class="description">Project data from ePM (Electronic Project Management). This
+
+service contains point, line and polygon layers for UDOT's
+
 roadway projects stored in ePM. </td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/EPM_Projects/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3359,9 +3369,12 @@ roadway projects stored in ePM. </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/3850b04f17c04935aedf03b47ad42aba_0">Facility Inventory</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Facilities inventory from the Operations Management System
-(OMS). Facility types include: brake check areas, road-closed
-gates, material storage locations, offices, port of entries, rest
+                <td data-th="description" class="description">Facilities inventory from the Operations Management System
+
+(OMS). Facility types include: brake check areas, road-closed
+
+gates, material storage locations, offices, port of entries, rest
+
 areas, runaway truck lanes, view areas, and welcome centers.</td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FacilityInventoryOMS/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3376,8 +3389,10 @@ areas, runaway truck lanes, view areas, and welcome centers.</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/7bfbfdb5c9d04a30b9fca5adf6443495_5">Intersections</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Intersection dataset contains location information of any cross
-street location to a state route. At state route to state route
+                <td data-th="description" class="description">Intersection dataset contains location information of any cross
+
+street location to a state route. At state route to state route
+
 intersections both routes are identified</td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3385,9 +3400,12 @@ intersections both routes are identified</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/e552d8405ade49e0b9a23297648af7f8_0">Islands</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Dataset contains median locations along state routes.
-Descriptive information includes median type, width, traffic
-island presence and protection presence. Width value of 999
+                <td data-th="description" class="description">Dataset contains median locations along state routes.
+
+Descriptive information includes median type, width, traffic
+
+island presence and protection presence. Width value of 999
+
 generally indicates large median greater than 300ft</td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3395,10 +3413,14 @@ generally indicates large median greater than 300ft</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/bb7d7cd500ff4fa3bb56bd39c7f297f7_0">Lanes</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">This dataset contains lane counts for Utah state highways.
-Descriptive information includes lanes by type( Aux, Through,
-Decel, Accel, Turn, Passing) and count of each type lane.
-Information also includes location information including x,y
+                <td data-th="description" class="description">This dataset contains lane counts for Utah state highways.
+
+Descriptive information includes lanes by type( Aux, Through,
+
+Decel, Accel, Turn, Passing) and count of each type lane.
+
+Information also includes location information including x,y
+
 and route & milepost.</td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FI_Lanes/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3420,10 +3442,14 @@ and route & milepost.</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/9bacb5f23e5c4fb6be91d40069aaad89_0">LRS Mileposts</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">This dataset approximates the location of mileposts along
-state routes in Utah. It was created by deriving a location from
-a polylineM route feature class that was calibrated at route
-endpoints and at intermediate points. The goal for positional
+                <td data-th="description" class="description">This dataset approximates the location of mileposts along
+
+state routes in Utah. It was created by deriving a location from
+
+a polylineM route feature class that was calibrated at route
+
+endpoints and at intermediate points. The goal for positional
+
 accuracy with this data set is 50 feet. </td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/MilePosts/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3431,10 +3457,14 @@ accuracy with this data set is 50 feet. </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/e552d8405ade49e0b9a23297648af7f8_1">Medians</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Dataset contains median locations along state routes.
-Descriptive information includes median type, width, traffic
-island presence and protection presence. Width value of 999
-generally indicates large median greater than 300ft. Location
+                <td data-th="description" class="description">Dataset contains median locations along state routes.
+
+Descriptive information includes median type, width, traffic
+
+island presence and protection presence. Width value of 999
+
+generally indicates large median greater than 300ft. Location
+
 information is generally accurate to within 5ft </td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3456,7 +3486,8 @@ information is generally accurate to within 5ft </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/7bfbfdb5c9d04a30b9fca5adf6443495_8">Pavement Messages</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Pavement messages data consists of message location,
+                <td data-th="description" class="description">Pavement messages data consists of message location,
+
 content and type. </td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FI_PavementMessages/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3464,9 +3495,12 @@ content and type. </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/7777bfb8d4b346e38a3ad3612a33fadb_0">Pavement Striping</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">This dataset contains pavement striping located along Utah
-state highways. Descriptive information includes paint color,
-pattern, and linear feet. Location information includes x,y and
+                <td data-th="description" class="description">This dataset contains pavement striping located along Utah
+
+state highways. Descriptive information includes paint color,
+
+pattern, and linear feet. Location information includes x,y and
+
 route & milepost.</td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FI_Striping/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3481,8 +3515,10 @@ route & milepost.</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/7bfbfdb5c9d04a30b9fca5adf6443495_10">Power Pedestals</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Power Pedestal data consists of location only. Location
-information includes x,y and mile post. Location information is
+                <td data-th="description" class="description">Power Pedestal data consists of location only. Location
+
+information includes x,y and mile post. Location information is
+
 generally accurate to within 5ft. </td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3490,7 +3526,8 @@ generally accurate to within 5ft. </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/a7ee5e6cc85742978d25449aae6c1941_0">Project Wise EPM</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">These layers provide access to ProjectWise data by Electronic
+                <td data-th="description" class="description">These layers provide access to ProjectWise data by Electronic
+
 Program Management (ePM) Project. </td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3540,10 +3577,14 @@ Program Management (ePM) Project. </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/477cd5f12e344ab08b40dfa9dd63af4e_0">Rumble Strips</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">This dataset contains rumble strips located along Utah state
-highways. Descriptive information includes lane type,
-pavement type, and paint striping attributes (color, style,
-width). Location information includes x,y and route &
+                <td data-th="description" class="description">This dataset contains rumble strips located along Utah state
+
+highways. Descriptive information includes lane type,
+
+pavement type, and paint striping attributes (color, style,
+
+width). Location information includes x,y and route &
+
 milepost. </td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FI_Rumblestrips/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3551,10 +3592,14 @@ milepost. </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/35c7bd85f9c347dbbde1ee7374379413_0">Shoulders</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">This dataset contains information about shoulder location and
-type. Descriptive information includes location; x&y, route
-and mile post, location (center,left,right). Also includes width
-and edge type. The width has been rounded to the nearest
+                <td data-th="description" class="description">This dataset contains information about shoulder location and
+
+type. Descriptive information includes location; x&y, route
+
+and mile post, location (center,left,right). Also includes width
+
+and edge type. The width has been rounded to the nearest
+
 whole foot for end use purposes. </td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FI_Shoulders/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3562,8 +3607,10 @@ whole foot for end use purposes. </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/7bfbfdb5c9d04a30b9fca5adf6443495_14">Signal Cabinets</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">This dataset contains signal cabinets located along Utah state
-highways. Location information includes x,y and route &
+                <td data-th="description" class="description">This dataset contains signal cabinets located along Utah state
+
+highways. Location information includes x,y and route &
+
 milepost. Elevation in meters is included. </td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3571,10 +3618,14 @@ milepost. Elevation in meters is included. </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/7bfbfdb5c9d04a30b9fca5adf6443495_15">Signal Poles</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">This dataset contains signal poles located along Utah state
-highways. Descriptive information includes mast arm type,
-signal type count, and the associated intersection's unique ID.
-Also included is location information including x,y and route &
+                <td data-th="description" class="description">This dataset contains signal poles located along Utah state
+
+highways. Descriptive information includes mast arm type,
+
+signal type count, and the associated intersection's unique ID.
+
+Also included is location information including x,y and route &
+
 milepost.</td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3582,9 +3633,12 @@ milepost.</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/ab35f1550eae45b0a93df9b19644347d_0">Sign Assemblies</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">This dataset contains sign assemblies located along Utah state
-highways. Descriptive information includes support type,
-offset, and sign count. Also included is location information
+                <td data-th="description" class="description">This dataset contains sign assemblies located along Utah state
+
+highways. Descriptive information includes support type,
+
+offset, and sign count. Also included is location information
+
 including x,y and route & milepost.</td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3592,8 +3646,10 @@ including x,y and route & milepost.</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/2c718a780caf47279fbc23c3401af4d7_0">Sign Face</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Sign face data includes the standard MUTCD or UDOT sign
-designation color and description, sign condition (good, fair,
+                <td data-th="description" class="description">Sign face data includes the standard MUTCD or UDOT sign
+
+designation color and description, sign condition (good, fair,
+
 poor), and sign orientation (north, southwest, etc.). </td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FI_SignFaces/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3601,11 +3657,16 @@ poor), and sign orientation (north, southwest, etc.). </td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="{% link data/transportation/index.html %}">SMS Safety Index</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">The Safety Index offers a statewide comparison of UDOT
-roadways, taking into account the different traffic patterns
-and volumes experienced in urban and rural areas. The Safety
-Index is a combination of four, equally weighted safety
-analysis sub-scores. The Safety Index is reported on a 0 to 10
+                <td data-th="description" class="description">The Safety Index offers a statewide comparison of UDOT
+
+roadways, taking into account the different traffic patterns
+
+and volumes experienced in urban and rural areas. The Safety
+
+Index is a combination of four, equally weighted safety
+
+analysis sub-scores. The Safety Index is reported on a 0 to 10
+
 scale, with 10 representing the worst conditions</td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/Safety_SafetyIndex/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3613,12 +3674,18 @@ scale, with 10 representing the worst conditions</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="{% link data/transportation/index.html %}">SMS Severe Crashes Per Mile</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">The Severe Crashes per Mile Score indicates which road
-segments have the highest number of total severe crashes per
-mile per year (2011-2013). Severe crashes are crashes that
-result in a fatality or an incapacitating injury. Severe Crashes
-per Mile Scores are reported on a 0 to 5 scale with 5
-representing the road segments with the most severe crashes
+                <td data-th="description" class="description">The Severe Crashes per Mile Score indicates which road
+
+segments have the highest number of total severe crashes per
+
+mile per year (2011-2013). Severe crashes are crashes that
+
+result in a fatality or an incapacitating injury. Severe Crashes
+
+per Mile Scores are reported on a 0 to 5 scale with 5
+
+representing the road segments with the most severe crashes
+
 per mile per year (weighted by roadway center line miles). </td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/Safety_SevCrashperMileScore/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>


### PR DESCRIPTION
not sure if this will fix this or if this page auto-generates. If this spelling with the space is coming from the page title I would be happy to change _lidar_ to proper case in the title