### PR TITLE
chore: bump version number is download links

### DIFF
--- a/_posts/2021-11-29-introducing-the-official-ugrc-api-client.md
+++ b/_posts/2021-11-29-introducing-the-official-ugrc-api-client.md
@@ -19,7 +19,7 @@ Since the creation of the [UGRC API](https://api.mapserv.utah.gov) over 10 years
 
 One-off address geocoding is very useful, but state agencies, local governments, private companies, etc., have large tabular datasets without locations. We built the ArcGIS [geocoding toolbox client]({% link data/address-geocoders-locators/index.html %}#GeocodingToolbox) to make the batch geocoding of hundreds of thousands of addresses simple. All of the clients that run within ArcGIS require an expensive software license. We think everyone should have free access to geocode Utah addresses --- and now they do.
 
-The official [UGRC API client](https://github.com/agrc/api-client) is now available to everyone! This cross-platform desktop application carefully guides you through your geocoding tasks. We analyzed the data from our other clients and made great improvements to the user experience. We think this is the best API client we have ever created. Go [download](https://github.com/agrc/api-client/releases) the official UGRC API Client right now for [MacOS](https://github.com/agrc/api-client/releases/download/v1.5.2/UGRC.API.Client-1.5.2-x64.dmg) or [Windows](https://github.com/agrc/api-client/releases/download/v1.5.2/ugrc-api-client-1.5.2-win32-setup.exe) and start geocoding.
+The official [UGRC API client](https://github.com/agrc/api-client) is now available to everyone! This cross-platform desktop application carefully guides you through your geocoding tasks. We analyzed the data from our other clients and made great improvements to the user experience. We think this is the best API client we have ever created. Go [download](https://github.com/agrc/api-client/releases) the official UGRC API Client right now for [MacOS](https://github.com/agrc/api-client/releases/download/v1.6.0/UGRC.API.Client-1.6.0-x64.dmg) or [Windows](https://github.com/agrc/api-client/releases/download/v1.6.0/ugrc-api-client-1.6.0-win32-setup.exe) and start geocoding.
 
 ![first screen]({% link images/api-client/client.png %})
 {: .flex .flex--center}
@@ -27,7 +27,7 @@ The official [UGRC API client](https://github.com/agrc/api-client) is now availa
 ## A few highlights we are proud of
 
 - No license is needed to use the client! It is download and go.
-- The client is cross-platform. It works on [MacOS](https://github.com/agrc/api-client/releases/download/v1.5.2/UGRC.API.Client-1.5.2-x64.dmg) and [Windows](https://github.com/agrc/api-client/releases/download/v1.5.2/ugrc-api-client-1.5.2-win32-setup.exe).
+- The client is cross-platform. It works on [MacOS](https://github.com/agrc/api-client/releases/download/v1.6.0/UGRC.API.Client-1.6.0-x64.dmg) and [Windows](https://github.com/agrc/api-client/releases/download/v1.6.0/ugrc-api-client-1.6.0-win32-setup.exe).
 - The client is evergreen. The app will automatically download updates as soon as they are available. Every time the application restarts, it will be the best, most recent version.
 - You only need to create one API key ever. Did your IP address change? No problem! Your access will not be interrupted.
 - API keys are validated before the geocoding task starts. The create a key, try to geocode, fail, read the error message, create a new key, succeed loop is broken!


### PR DESCRIPTION
I wonder if we could do this via the deploy action in agrc/api-client...