### PR TITLE
change urls for district combo areas

### DIFF
--- a/data/sgid-index/index.html
+++ b/data/sgid-index/index.html
@@ -2846,14 +2846,14 @@ Horizontal_Positional_Accuracy: GPS = geocode or aerial imagery placement; Asser
                 <td data-th="name" class="name">District Combination Areas 2012</td>
                 <td data-th="agency" class="agency"></td>
                 <td data-th="description" class="description"></td>
-                <td data-th="service" class="service"><a href="https://opendata.gis.utah.gov/datasets/utah-political-district-combination-areas-2012" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
+                <td data-th="service" class="service"><a href="https://opendata.gis.utah.gov/datasets/utah-district-combination-areas-2012" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
             <tr>
                 <td data-th="category" class="category">political</td>
                 <td data-th="name" class="name">District Combination Areas 2022</td>
                 <td data-th="agency" class="agency"></td>
                 <td data-th="description" class="description">Combination of the Utah 2022 district boundaries</td>
-                <td data-th="service" class="service"><a href="https://opendata.gis.utah.gov/datasets/utah-political-district-combination-areas-2022" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
+                <td data-th="service" class="service"><a href="https://opendata.gis.utah.gov/datasets/utah-district-combination-areas-2022" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
             <tr>
                 <td data-th="category" class="category">political</td>
@@ -3286,7 +3286,8 @@ Horizontal_Positional_Accuracy: GPS = geocode or aerial imagery placement; Asser
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/search?q=aadt">AADT</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Average Annual Daily Traffic (AADT)  on road sections of the State
+                <td data-th="description" class="description">Average Annual Daily Traffic (AADT)  on road sections of the State
+
 Highways or Local Federal-Aid roads</td>
                 <td data-th="service" class="service"></td>
             </tr>
@@ -3331,7 +3332,8 @@ types. Location information includes x,y and route & milepost.</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/9df4865bcb1a4f86b7a8afa43a34b3d0_0">Bike Lanes</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Bike Lane locations along state routes. This file indicates
+                <td data-th="description" class="description">Bike Lane locations along state routes. This file indicates
+
 where a bike lane with paint striping is present only</td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/FI_BikeLanes/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>
@@ -3339,7 +3341,8 @@ where a bike lane with paint striping is present only</td>
                 <td data-th="category" class="category">transportation</td>
                 <td data-th="name" class="name"><a href="https://data-uplan.opendata.arcgis.com/datasets/a3ef645a46584390846f0445a83959d4_0">Cattle Guard Inventory</a></td>
                 <td data-th="agency" class="agency">UDOT</td>
-                <td data-th="description" class="description">Cattle guard inventory data comes from the Operations
+                <td data-th="description" class="description">Cattle guard inventory data comes from the Operations
+
 Management System (OMS)</td>
                 <td data-th="service" class="service"><a href="https://maps.udot.utah.gov/arcgis/rest/services/CattleguardInventoryOMS/MapServer" class="pull-right">{% include fa_icon.html api=true class="svg-inline--fa fa-w-20 fa-fw" %}</i></a></td>
             </tr>


### PR DESCRIPTION
I changed URLs for the 2012 and 2022 areas
there are two openData pages for the 2012 now after the redirects/url changes on gis.utah.gov:
https://opendata.gis.utah.gov/datasets/utah-political-district-combination-areas-2012
https://opendata.gis.utah.gov/datasets/utah-political-combination-areas-2012