### PR TITLE
fix: 2010 metadata link

### DIFF
--- a/data/demographic/census/index.html
+++ b/data/demographic/census/index.html
@@ -147,7 +147,7 @@ with just a few modifications for usability." %}
     <h5>Related Resources</h5>
     <ul class="dotless">
       <li><a
-          href="ftp://ftp.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_metc/society_census2010tiger/metadata/metadata.html#Entity_and_Attribute_Information">Metadata</a>
+          href="https://www2.census.gov/census_2010/01-Redistricting_File--PL_94-171/0FILE_STRUCTURE.pdf">Metadata</a>
       <li><a href="https://www.census.gov/">U.S. Census Bureau</a>
     </ul>
     <p>{% include contact.html subject=page.title contact=site.data.contacts.agrc %}</p>


### PR DESCRIPTION
The existing metadata link went to an ftp:// site, and current browsers don't seem to handle ftp anymore. Regardless, the linked document didn't explain the field names. This document comes from the SDE metadata and has the proper field definitions for Block, Block Group, and Tracts. The counties fields are a subset of the fields in these other layers, so it works for them as well.

This is necessary because the Open SGID doesn't include the field aliases that are in the SDE.