### PR TITLE
Update: Address Data HTML

### DIFF
--- a/data/location/address-data/index.html
+++ b/data/location/address-data/index.html
@@ -32,6 +32,9 @@ AddressSystemQuadrants:
     name: Utah Address System Quadrants
     item_id: 3d6d2db8f3554cc8b3ff24b820035fb3
   updates:
+    - December 2022 - Added several address grids in Beaver county (Elk Meadows, Ponderosa,
+      Greenville, Adamsville, Sulphurdale).  Made major updates to grids in Utah, Cache, Tooele,
+      and Box Elder Counties.  Renamed 'NSL' to 'North Salt Lake' and 'East Carbon City' to 'East Carbon'.
     - August 2022 - Added the Rocky Ridge address system in northern Juab county
     - September 2021 - Updates near Elsinore/Central Valley/Monroe corners due to recent
       Elsinore annexation and inputs from Sevier County
@@ -53,9 +56,6 @@ AddressSystemQuadrants:
       Lewiston, and Snowville
     - February 2015 - Improvements were made to the Orderville address system boundary
       to match the municipal boundary
-    - January 2015 - Updated address system boundaries to match annexations in American
-      Fork, Farmington, Elk Ridge, Grantsville, Lehi, Mendon, Mount Pleasant, Payson,
-      Provo, Spanish Fork, and Washington
 
 ---
 <figure class="caption caption--right">


### PR DESCRIPTION
Data page update for changes to address system quadrants.  Added several address grids in Beaver county (Elk Meadows, Ponderosa, Greenville, Adamsville, Sulphurdale).  Made major updates to grids in Utah, Cache, Tooele, and Box Elder Counties.  Renamed 'NSL' to 'North Salt Lake' and 'East Carbon City' to 'East Carbon'.