### PR TITLE
added ' & 3.x'

### DIFF
--- a/discover/resources/index.md
+++ b/discover/resources/index.md
@@ -41,7 +41,7 @@ The pre-2018 `NAIP` layers have a stated horizontal positional accuracy of 5 met
 ### Adding a WMTS or WMS Service to ESRI Products
 {: .text-left}
 
-**ArcGIS Pro 2.x:**
+**ArcGIS Pro 2.x & 3.x:**
 
 1. `Insert -> Connections -> New WMTS Server`
 1. Paste the `WMTS` link [you have been provided]({% link discover/index.html %}#connect "view Discover sign up information") into the `Server URL:` line and click `OK`


### PR DESCRIPTION
I just want to get this updated. If you want `ArcGIS Pro 2.x or higher` or `ArcGIS Pro 2.x or greater` I am fine with that.