### PR TITLE
update: zip code area HTML

### DIFF
--- a/data/boundaries/zip-codes/index.html
+++ b/data/boundaries/zip-codes/index.html
@@ -34,6 +34,19 @@ ZipCodeBoundaries:
 {% include abstract.html name="Zip Codes" stewards="UGRC" abstract="This dataset
 contains the estimated geographic extents for all five digit zip codes in Utah
 that are not P.O. box only." %}
+
+<div>
+    <h5>Related Resources</h5>
+    <ul class="dotless">
+      <li><a href="{% link data/location/u-s-postal-service/index.html %}">US Postal Service data page</a></li>
+        <ul>
+          <li><a href="{% link data/location/u-s-postal-service/index.html %}#USPSPostOffices">USPS Post Offices</a>
+          <li><a href="{% link data/location/u-s-postal-service/index.html %}#ZipCodePOBoxes">Zip Code PO Boxes and Delivery Points</a></li>
+        </ul>
+      </li>
+    </ul>
+</div>
+
 <div class="grid package">
   <div class="grid__col grid__col--12-of-12">
     <h3 id="ZipCodeBoundaries">Zip Code Boundaries</h3>


### PR DESCRIPTION
A quick update to link to USPS related resources from the zip code areas page.  That way, a user could more easily find the zip code point locations (PO boxes, delivery points, etc.) from the zip code areas page.