### PR TITLE
feat: specify layer id for downloads, fix uta

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ Item:
   hub:
     name: ArcGIS Online name exactly eg Utah Address Points [required]
     alias:  The name you would prefer to display instead of the value for name [optional]
-    item_id: the item id [required]
-    org: the sharing org name e.g. `SITLA`. When an org shares items it gets prefixed with their name e.g. `/SITLA::land-ownership`
-    skip_shapefile: true or false [optional]
-    skip_fgdb: true or false [optional]
-    skip_hub: true or false [optional]
+    item_id: The item id [required]
+    layer_id: The layer id within the feature service [optional]. Defaults to 0 (for services with a single layer).
+    org: The sharing org name e.g. `SITLA`. When an org shares items it gets prefixed with their name e.g. `/SITLA::land-ownership`
+    skip_shapefile: True or false [optional]
+    skip_fgdb: True or false [optional]
+    skip_hub: True or false [optional]
 ```

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -8,14 +8,20 @@
 {%- if display_name == "" or display_name == nil %}
 {% assign display_name = include.name %}
 {%- endif -%}
+{%- if include.layer_id == nil %}
+{% assign layer_id = 0 %}
+{%- else -%}
+{% assign layer_id = include.layer_id %}
+{%- endif -%}
+
 {%- if include.skip_hub == nil or include.skip_hub == false -%}
 <li><a href="https://opendata.gis.utah.gov/datasets/{{ dataset_id }}" id="{{ id }}-hub">{{ display_name }}: SGID Open Data Downloads and APIs</a>
 {%- endif -%}
 {%- if include.skip_fgdb == nil or include.skip_fgdb == false -%}
-<li><a href="https://opendata.arcgis.com/datasets/{{ include.item_id }}_0.gdb" id="{{ id }}-gdb">{{ display_name }}: File Geodatabase</a>
+<li><a href="https://opendata.arcgis.com/datasets/{{ include.item_id }}_{{ layer_id }}.gdb" id="{{ id }}-gdb">{{ display_name }}: File Geodatabase</a>
 {%- endif -%}
 {%- if include.skip_shapefile == nil or include.skip_shapefile == false -%}
-<li><a href="https://opendata.arcgis.com/datasets/{{ include.item_id }}_0.zip" id="{{ id }}-shp">{{ display_name }}: Shapefile</a>
+<li><a href="https://opendata.arcgis.com/datasets/{{ include.item_id }}_{{ layer_id }}.zip" id="{{ id }}-shp">{{ display_name }}: Shapefile</a>
 {%- endif -%}
 <script>
   {%- if include.skip_shapefile == nil or include.skip_shapefile == false -%}

--- a/_includes/packagedata.html
+++ b/_includes/packagedata.html
@@ -15,7 +15,7 @@
           org=include.info.hub.org
           name=include.info.hub.name
           item_id=include.info.hub.item_id
-          layer_id=included.info.hub.layer_id
+          layer_id=include.info.hub.layer_id
           alias = include.info.hub.alias
           skip_fgdb = include.info.hub.skip_fgdb
         %}

--- a/_includes/packagedata.html
+++ b/_includes/packagedata.html
@@ -15,6 +15,7 @@
           org=include.info.hub.org
           name=include.info.hub.name
           item_id=include.info.hub.item_id
+          layer_id=included.info.hub.layer_id
           alias = include.info.hub.alias
           skip_fgdb = include.info.hub.skip_fgdb
         %}

--- a/data/transportation/transit/index.html
+++ b/data/transportation/transit/index.html
@@ -17,6 +17,7 @@ UTARoutesAndMostRecentRidership:
     name: uta routes and most recent ridership 1
     alias: UTA Routes & Most Recent Ridership
     item_id: 4347f3565fbe4d5dbb97b016768b8907
+    layer_id: 128
     org: rideuta
   updates:
     - February, 2021
@@ -25,6 +26,7 @@ UTAStopsAndMostRecentRidership:
     name: uta stops and most recent ridership 1
     alias: UTA Stops & Most Recent Ridership
     item_id: 7acc9d583379456eacfbb82e5ff07370
+    layer_id: 138
     org: rideuta
   updates:
     - January, 2021


### PR DESCRIPTION
The download links for gdb/shapefiles appear to use the layer id within the feature service to define what gets downloaded. We've hardcoded in `0` (because we stick to the one layer per service rule), but we have no control over other agencies. This should allow us to specify it when needed, and leave it 0 if not specified.