### PR TITLE
update parcel page documentation

### DIFF
--- a/data/cadastre/parcels/index.html
+++ b/data/cadastre/parcels/index.html
@@ -37,7 +37,7 @@ abstract=abstract %}
     <p>In 2005, HB113 was passed requiring the UGRC Cadastral Surveyor to work with local government to create a parcel
       database for the State.
     <p>
-    <blockquote>63F-1-506.(3) (c) coordinate with county recorders and surveyors to create a statewide parcel layer in
+    <blockquote><a href="https://le.utah.gov/xcode/Title63A/Chapter16/63A-16-S505.html">63A-16-505.(3)(vi)</a> coordinate with county recorders and surveyors to create a statewide parcel layer in
       the State Geographic Information Database (SGID) containing parcel boundary, parcel identifier, parcel address,
       owner type, and county recorder contact information.</blockquote>
     </p>


### PR DESCRIPTION
change state code reference numbers
link to state code page
this was pointed out by the state auditors office. they found it while working on some new administrative rule