### PR TITLE
fix to allow data downloads

### DIFF
--- a/data/transportation/roads-system/index.html
+++ b/data/transportation/roads-system/index.html
@@ -23,12 +23,10 @@ HighwayLinearReferencingSystemRoutes:
       add additional routes, and in response to route realignment.
 MilepostPoints:
   hub:
-    name: physical location of reference post rp
+    name: physical location of reference post rp open data
     alias: Utah Mile Reference Posts
-    item_id: 768b285ed14e40e5853f45963f2d137a
+    item_id: 01aa9e5e832c459db43dc6e27f30c3ae
     org: uplan
-    skip_shapefile: True
-    skip_fgdb: True
   updates:
     - Updates to this dataset are published periodically
 FreewayExitPoints:


### PR DESCRIPTION
udot updated the link/service one more time to enable data downloads on this layer.  The previous link/service did not allow data downloads.