### PR TITLE
fix: switch to better docker image for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,9 @@ version: "3"
 services:
   jekyll:
     container_name: "gis.utah.gov"
-    image: "jekyll/jekyll:4"
-    command: "jekyll serve --watch --livereload --incremental"
+    image: "bretfisher/jekyll-serve"
     volumes:
-      - "./:/srv/jekyll"
+      - "./:/site"
     ports:
       - "4000:4000"
       - "35729:35729"


### PR DESCRIPTION
I couldn't get the jekyll/jekyll image to build properly. I ran into this issue: https://github.com/jekyll/jekyll-sass-converter/issues/161. This image seems to work better. I'm not sure of all of the ramifications of this change but thought that it was worth opening a PR for it.