### PR TITLE
fix: fix link colors that are within detail elements

### DIFF
--- a/src/components/data/Disclaimer.astro
+++ b/src/components/data/Disclaimer.astro
@@ -8,7 +8,7 @@ const { style = 'primary' } = Astro.props;
 
 <details
   class:list={[
-    'rounded-lg border border-zinc-400 bg-primary px-6 py-3 text-white dark:border-white/20 [&_svg]:open:-rotate-180',
+    'rounded-lg border border-zinc-400 bg-primary px-6 py-3 text-white dark:border-white/20 [&_summary_svg]:open:-rotate-180',
     style === 'secondary' && 'dark:bg-secondary',
   ]}
 >

--- a/src/components/data/UpdateHistory.astro
+++ b/src/components/data/UpdateHistory.astro
@@ -9,7 +9,7 @@ const { updates, style = 'primary' } = Astro.props;
 
 <details
   class:list={[
-    'rounded-lg border border-zinc-400 bg-primary px-6 py-3 text-white dark:border-white/20 [&_svg]:open:-rotate-180',
+    'rounded-lg border border-zinc-400 bg-primary px-6 py-3 text-white dark:border-white/20 [&_summary_svg]:open:-rotate-180',
     style === 'secondary' && 'dark:bg-secondary',
   ]}
 >

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -8,6 +8,9 @@
   .stripe-background a:not(.custom-style) {
     @apply text-secondary hover:text-primary dark:text-accent hover:dark:text-accent;
   }
+  .stripe-background details a:not(.custom-style) {
+    @apply text-accent hover:bg-white/10 hover:text-accent;
+  }
   .primary-background a:not(.custom-style) {
     @apply text-accent hover:bg-white/10;
   }


### PR DESCRIPTION
Fixes #2523

Before these changes, the external link icons were being rotated within detail elements.