### PR TITLE
feat: usgs-tile-index page

### DIFF
--- a/src/data/downloadMetadata.ts
+++ b/src/data/downloadMetadata.ts
@@ -1400,8 +1400,8 @@ export const dataPages: DownloadMetadata = {
   'Utah USGS 24K Quarter Quads': {
     itemId: 'baa0bf569643469a9511e1fb753f4a60',
     name: 'Utah USGS 24K Quarter Quads',
-    featureServiceId: null,
-    openSgid: '',
+    featureServiceId: 'USGS24KQuarterQuads',
+    openSgid: 'indices.usgs_24k_quarter_quads',
     layerId: 0,
   },
   'Utah USGS DEM Extents': {
@@ -1414,15 +1414,15 @@ export const dataPages: DownloadMetadata = {
   'Utah USGS 250K Quads 1x1': {
     itemId: '606d75b70d254c7e9da5785704c60369',
     name: 'Utah USGS 250K Quads 1x1',
-    featureServiceId: null,
-    openSgid: '',
+    featureServiceId: 'USGS250KQuads1x1',
+    openSgid: 'indices.usgs_250k_quads_1x1',
     layerId: 0,
   },
   'Utah USGS 250K Quads 1x2': {
     itemId: 'ed39436090e8472593149659b4ed257e',
     name: 'Utah USGS 250K Quads 1x2',
-    featureServiceId: null,
-    openSgid: '',
+    featureServiceId: 'USGS250KQuads1x2',
+    openSgid: 'indices.usgs_250k_quads_1x2',
     layerId: 0,
   },
   'Utah Google Flight Blocks': {
@@ -1435,15 +1435,15 @@ export const dataPages: DownloadMetadata = {
   'Utah USGS 100K Quads': {
     itemId: '80042c4b51a843c3b480ada0b8d68177',
     name: 'Utah USGS 100K Quads',
-    featureServiceId: null,
-    openSgid: '',
+    featureServiceId: 'USGS100KQuads',
+    openSgid: 'indices.usgs_100k_quads',
     layerId: 0,
   },
   'Utah USGS 24K Quads': {
     itemId: 'fe10115354c14260aef62a60b3137488',
     name: 'Utah USGS 24K Quads',
-    featureServiceId: null,
-    openSgid: '',
+    featureServiceId: 'USGS24KQuads',
+    openSgid: 'indices.usgs_24k_quads',
     layerId: 0,
   },
   'Utah LiDAR Extents': {

--- a/src/layouts/DataPage.astro
+++ b/src/layouts/DataPage.astro
@@ -13,6 +13,7 @@ interface Props {
   actionUrl?: string;
   config?: {
     skipInDepth?: boolean;
+    stripeDescription?: boolean;
   };
 }
 
@@ -37,7 +38,7 @@ const { title = 'UGRC', subTitle, category, actionUrl, config } = Astro.props;
   {
     !(config?.skipInDepth ?? false) && (
       <>
-        <Section title="A closer look" stripe titlePosition="center">
+        <Section title="A closer look" stripe={!(config?.stripeDescription ?? false)} titlePosition="center">
           <slot name="description" />
           <slot name="update-history" />
           <slot name="disclaimer" />

--- a/src/pages/products/sgid/indices/usgs-tile-index.astro
+++ b/src/pages/products/sgid/indices/usgs-tile-index.astro
@@ -1,0 +1,105 @@
+---
+import Layout from '@layouts/DataPage.astro';
+
+import type { IMetadata, IPageMetadata } from '@models/products/sgid/types';
+import { ProductType, SgidCategory } from '@models/products/sgid/types';
+
+import HubDownloads from '@components/data/HubDownloads.astro';
+import Metadata from '@components/data/Metadata.astro';
+
+import CardWithPopularLink from '@components/page/CardWithPopularLink.astro';
+import CardWithSmallLink from '@components/page/CardWithSmallLink.astro';
+import GridForMoreResources from '@components/page/GridForMoreResources.astro';
+import GridForYouMightLike from '@components/page/GridForYouMightLike.astro';
+import Section from '@components/page/Section.astro';
+
+import BulletedList from '@components/page/BulletedList.astro';
+
+import { dataPages } from '@data/downloadMetadata';
+
+export const metadata: IMetadata = {
+  title: 'Topographic Map Indices',
+  description: `This dataset contains GIS mapping data representing the tile indices for the 24K, 100K, and 250K USGS scanned topographic maps (DRGs).`,
+  stewards: ['UGRC', 'U.S. Geological Survey'],
+  type: ProductType.POLYGON,
+  category: SgidCategory.INDICES,
+};
+
+const page: IPageMetadata = {
+  ...metadata,
+
+  updateHistory: [`Never`],
+};
+---
+
+<Layout title={page.title} subTitle={page.updateHistory[0]} category={page.category} actionUrl={page.application}>
+  <Metadata slot="metadata" {...page} />
+
+  <Fragment slot="summary">
+    <p>
+      USGS Topographic Map tile indices can be used to determine the 7.5 minute - 1:24,000, 30x60 minute - 1:100,000,
+      1x1 and 1x2 degree - 1:250,000 scale map boundaries for Utah.
+    </p>
+  </Fragment>
+
+  <Section title="Use the data: USGS 24K Quad Boundaries" slot="downloads" titlePosition="center">
+    <HubDownloads {...dataPages['Utah USGS 24K Quads']} />
+  </Section>
+  <Section title="Use the data: USGS 100K Quad Boundaries" slot="downloads" titlePosition="center" stripe>
+    <HubDownloads {...dataPages['Utah USGS 100K Quads']} />
+  </Section>
+  <Section title="Use the data: USGS 250K Quad Boundaries 1x1" slot="downloads" titlePosition="center">
+    <HubDownloads {...dataPages['Utah USGS 250K Quads 1x1']} />
+  </Section>
+  <Section title="Use the data: USGS 250K Quad Boundaries 1x2" slot="downloads" titlePosition="center">
+    <HubDownloads {...dataPages['Utah USGS 250K Quads 1x2']} />
+  </Section>
+
+  <Fragment slot="description">
+    <p>
+      <h3>The 24K tile index contains the following attribute fields:</h3>
+      <BulletedList>
+        <li>Name - the name of the map</li>
+        <li>OHIO_CODE - code used by USGS</li>
+        <li>TILE - the UGRC q number tile name</li>
+      </BulletedList>
+      <h3>The 100K tile index contains the following attribute fields:</h3>
+      <BulletedList>
+        <li>Name - the name of the map</li>
+        <li>TILE - the UGRC q number tile name</li>
+      </BulletedList>
+      <h3>The 250K tile indices contains the following attribute fields:</h3>
+      <BulletedList>
+        <li>USGS_CODE - code used by USGS</li>
+        <li>TILE_NAME - the UGRC q number tile name</li>
+      </BulletedList>
+    </p>
+    <p>
+      The native spatial reference for these dataset are UTM Zone 12N, NAD83 (0.01 meter coordinate precision). There
+      are no constraints or warranties with regard to the use of this dataset. Users are encouraged to attribute content
+      to: State of Utah, SGID.
+    </p>
+  </Fragment>
+
+  <Section title="More resources" slot="more-resources" stripe titlePosition="center">
+    <GridForMoreResources>
+      <CardWithPopularLink title="UGRC Raster Data Discovery" href="https://raster.utah.gov/?products=5"
+        >Download USGS topographic maps.</CardWithPopularLink
+      >
+      <CardWithPopularLink title="The National Map" href="https://apps.nationalmap.gov/downloader/"
+        >Download USGS topographic GeoPDF maps.</CardWithPopularLink
+      >
+    </GridForMoreResources>
+  </Section>
+
+  <Section title="You might also like" slot="you-might-also-like" titlePosition="center">
+    <GridForYouMightLike>
+      <CardWithSmallLink title="Topographic maps" href="/products/sgid/usgs-scanned-topographic-maps" style="secondary"
+        >USGS scanned topographic maps</CardWithSmallLink
+      >
+      <CardWithSmallLink title="Boundaries" href="/products/sgid/boundaries" style="secondary"
+        >Boundaries page</CardWithSmallLink
+      >
+    </GridForYouMightLike>
+  </Section>
+</Layout>

--- a/src/pages/products/sgid/indices/usgs-tile-index.astro
+++ b/src/pages/products/sgid/indices/usgs-tile-index.astro
@@ -22,6 +22,7 @@ export const metadata: IMetadata = {
   stewards: ['UGRC', 'U.S. Geological Survey'],
   type: ProductType.POLYGON,
   category: SgidCategory.INDICES,
+  secondaryCategory: SgidCategory.TOPO,
 };
 
 const page: IPageMetadata = {

--- a/src/pages/products/sgid/indices/usgs-tile-index.astro
+++ b/src/pages/products/sgid/indices/usgs-tile-index.astro
@@ -7,13 +7,12 @@ import { ProductType, SgidCategory } from '@models/products/sgid/types';
 import HubDownloads from '@components/data/HubDownloads.astro';
 import Metadata from '@components/data/Metadata.astro';
 
+import BulletedList from '@components/page/BulletedList.astro';
 import CardWithPopularLink from '@components/page/CardWithPopularLink.astro';
 import CardWithSmallLink from '@components/page/CardWithSmallLink.astro';
 import GridForMoreResources from '@components/page/GridForMoreResources.astro';
 import GridForYouMightLike from '@components/page/GridForYouMightLike.astro';
 import Section from '@components/page/Section.astro';
-
-import BulletedList from '@components/page/BulletedList.astro';
 
 import { dataPages } from '@data/downloadMetadata';
 
@@ -32,7 +31,15 @@ const page: IPageMetadata = {
 };
 ---
 
-<Layout title={page.title} subTitle={page.updateHistory[0]} category={page.category} actionUrl={page.application}>
+<Layout
+  title={page.title}
+  subTitle={page.updateHistory[0]}
+  category={page.category}
+  actionUrl={page.application}
+  config={{
+    stripeDescription: true,
+  }}
+>
   <Metadata slot="metadata" {...page} />
 
   <Fragment slot="summary">
@@ -51,29 +58,27 @@ const page: IPageMetadata = {
   <Section title="Use the data: USGS 250K Quad Boundaries 1x1" slot="downloads" titlePosition="center">
     <HubDownloads {...dataPages['Utah USGS 250K Quads 1x1']} />
   </Section>
-  <Section title="Use the data: USGS 250K Quad Boundaries 1x2" slot="downloads" titlePosition="center">
+  <Section title="Use the data: USGS 250K Quad Boundaries 1x2" slot="downloads" titlePosition="center" stripe>
     <HubDownloads {...dataPages['Utah USGS 250K Quads 1x2']} />
   </Section>
 
   <Fragment slot="description">
-    <p>
-      <h3>The 24K tile index contains the following attribute fields:</h3>
-      <BulletedList>
-        <li>Name - the name of the map</li>
-        <li>OHIO_CODE - code used by USGS</li>
-        <li>TILE - the UGRC q number tile name</li>
-      </BulletedList>
-      <h3>The 100K tile index contains the following attribute fields:</h3>
-      <BulletedList>
-        <li>Name - the name of the map</li>
-        <li>TILE - the UGRC q number tile name</li>
-      </BulletedList>
-      <h3>The 250K tile indices contains the following attribute fields:</h3>
-      <BulletedList>
-        <li>USGS_CODE - code used by USGS</li>
-        <li>TILE_NAME - the UGRC q number tile name</li>
-      </BulletedList>
-    </p>
+    <h3>The 24K tile index contains the following attribute fields:</h3>
+    <BulletedList>
+      <li>Name - the name of the map</li>
+      <li>OHIO_CODE - code used by USGS</li>
+      <li>TILE - the UGRC q number tile name</li>
+    </BulletedList>
+    <h3>The 100K tile index contains the following attribute fields:</h3>
+    <BulletedList>
+      <li>Name - the name of the map</li>
+      <li>TILE - the UGRC q number tile name</li>
+    </BulletedList>
+    <h3>The 250K tile indices contains the following attribute fields:</h3>
+    <BulletedList>
+      <li>USGS_CODE - code used by USGS</li>
+      <li>TILE_NAME - the UGRC q number tile name</li>
+    </BulletedList>
     <p>
       The native spatial reference for these dataset are UTM Zone 12N, NAD83 (0.01 meter coordinate precision). There
       are no constraints or warranties with regard to the use of this dataset. Users are encouraged to attribute content


### PR DESCRIPTION
The Closer Look bullets and striping could use some help

This needs to be added to the 24k hub section but I can't remember how: 
<ExternalLink href="https://utah.maps.arcgis.com/home/item.html?id=baa0bf569643469a9511e1fb753f4a60">USGS 24K Quarter Quads</ExternalLink>.

I don't remember the discussion but at some time Scott pointed out we were using the term 'indices' incorrectly. The page might need edits based on recollection.