### PR TITLE
fix: remove link to unmaintained application

### DIFF
--- a/src/content/blog/2021-02-19-intergenerational-poverty.md
+++ b/src/content/blog/2021-02-19-intergenerational-poverty.md
@@ -31,7 +31,7 @@ Using spatial tools like suitability analysis, we can highlight areas on a map t
 
 Geographic information systems allow us to ask big questions. As a community tool, GIS can empower residents and community leaders to make smarter decisions. When addressing intergenerational poverty, the key is to provide residents with access to services that give them a fair opportunity to succeed. Planning for the success of future generations involves investing in these services now. As we move forward, GIS should be a required tool in the community toolbox.
 
-> Take a look at UGRC’s [**interactive neighborhood suitability map**](/developer/applications/suitability) to further explore the map below. The layers in this map give the user the ability to discover areas in the state where residents do and do-not have access to essential services, such as childcare, hospitals, grocery stores, libraries, and transit stops. This map shows a sample of what can be done using GIS and spatial analysis.
+For example, the layers in the screenshot below give the user the ability to discover areas in the state where residents do and do-not have access to essential services, such as childcare, hospitals, grocery stores, libraries, and transit stops. This map shows a sample of what can be done using GIS and spatial analysis.
 
 Figure 1: Suitability Analysis along the Wasatch Front
 ![Suitability Analysis Wasatch Front](../../images/pillar-blog/2021-02-19-intergenerational-poverty/suitability_analysis_wasatchfront.png)


### PR DESCRIPTION
Steve and I talked and decided that it wasn't worth creating an entire project (GH repo, GCP project, Firebase DNS, etc) for an app that is only referenced once in our whole site in an older blog post. If this application ever gets prioritized for enhancements/reusability, we can create a legit project at that time.