### PR TITLE
fix: wrap stack traces in code block to prevent broken table syntax

### DIFF
--- a/scripts/validate-sgid-index.mjs
+++ b/scripts/validate-sgid-index.mjs
@@ -303,7 +303,7 @@ for (const row of rows) {
 
     changed = changed || checksChanged;
   } catch (error) {
-    recordError(`message: ${error.message} | stack: ${error.stack}`, row);
+    recordError(`message: ${error.message} stack: ${error.stack.replaceAll('\n', '<br/>')}`, row);
   }
 
   if (changed) {


### PR DESCRIPTION
![image](https://github.com/agrc/gis.utah.gov/assets/1326248/48b1355d-a2c0-432e-82bb-bac5e8d010fe)
