### PR TITLE
chore: HUI update history

### DIFF
--- a/src/pages/products/sgid/planning/housing-unit-inventory.astro
+++ b/src/pages/products/sgid/planning/housing-unit-inventory.astro
@@ -30,8 +30,9 @@ export const metadata: IMetadata = {
 const page: IPageMetadata = {
   ...metadata,
   updateHistory: [
-    `January 2024 - Initial load for Washington County`,
-    `May 2022 - Initial load for Salt Lake, Davis, and Weber Counties`,
+    `April 2024 - Update for Salt Lake, Davis, and Weber Counties (data current to January 2022)`,
+    `January 2024 - Initial load for Washington County (data current to December 2023)`,
+    `May 2022 - Initial load for Salt Lake, Davis, and Weber Counties (data current to January 2020)`,
   ],
   hub: {
     ...dataPages[metadata.pageTitle],


### PR DESCRIPTION
Update the Update History for the Housing Unit Inventory to reflect latest WFRC update.

Also include the data currency info. @bert-granberg, does this accomplish what you mentioned in your email?