### PR TITLE
fix(validation): validate that hub slugs match the names

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -8,6 +8,7 @@
       "name": "scripts",
       "dependencies": {
         "@octokit/rest": "^21.0.1",
+        "change-case": "^5.4.4",
         "fast-xml-parser": "^4.4.1",
         "glob": "^11.0.0",
         "google-auth-library": "^9.11.0",
@@ -297,6 +298,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,6 +5,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^21.0.1",
+    "change-case": "^5.4.4",
     "fast-xml-parser": "^4.4.1",
     "glob": "^11.0.0",
     "google-auth-library": "^9.11.0",

--- a/scripts/utilities.mjs
+++ b/scripts/utilities.mjs
@@ -1,3 +1,4 @@
+import * as changeCase from 'change-case';
 import knex from 'knex';
 import ky from 'ky';
 
@@ -140,4 +141,12 @@ export async function validateOpenDataUrl(url) {
     data: response.data[0],
     message: 'valid open data url',
   };
+}
+
+export function slugify(name) {
+  return changeCase.kebabCase(
+    name
+      .toLowerCase()
+      .replace('\'', '')
+  );
 }

--- a/scripts/utilities.test.mjs
+++ b/scripts/utilities.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { validateOpenDataUrl, validateOpenSgidTableName, validateUrl } from './utilities.mjs';
+import { slugify, validateOpenDataUrl, validateOpenSgidTableName, validateUrl } from './utilities.mjs';
 
 describe('validateUrl', () => {
   it('handles a valid url', async () => {
@@ -64,6 +64,19 @@ describe('validateOpenDataUrl', () => {
     it(`should return ${test[1]} for ${test[0]}`, async () => {
       const result = await validateOpenDataUrl(test[0]);
       assert.equal(result.valid, test[1]);
+    });
+  }
+});
+
+describe('slugify', () => {
+  const tests = [
+    ['Utah H3 Hexes Level 5', 'utah-h3-hexes-level-5'],
+    ['Name with an apostrophe hell\'o', 'name-with-an-apostrophe-hello'],
+  ]
+
+  for (const [input, expected] of tests) {
+    it(`slugifies ${input} to ${expected}`, () => {
+      assert.equal(slugify(input), expected);
     });
   }
 });

--- a/scripts/validate-sgid-index.mjs
+++ b/scripts/validate-sgid-index.mjs
@@ -5,7 +5,7 @@ import ky from 'ky';
 import ProgressBar from 'progress';
 import * as tsImport from 'ts-import';
 import { v4 as uuid } from 'uuid';
-import { validateOpenDataUrl, validateOpenSgidTableName, validateUrl } from './utilities.mjs';
+import { slugify, validateOpenDataUrl, validateOpenSgidTableName, validateUrl } from './utilities.mjs';
 
 const downloadMetadata = await tsImport.load('../src/data/downloadMetadata.ts');
 
@@ -191,13 +191,20 @@ async function itemId(row) {
     'Utah SHPO': 'UtahSHPO',
   };
 
-  const org = hubData.data.attributes.slug
-    ? hubData.data.attributes.slug.split('::')[0]
+  const slug = hubData.data.attributes.slug;
+
+  const correctSlug = slugify(hubData.data.attributes.name);
+  if (slug.split('::')[1] !== correctSlug) {
+    recordError(`slug: "${slug}" does not match hub name: "${hubData.data.attributes.name}". You may need to temporarily rename the item in Hub and then change it back to fix it.`, row);
+  }
+
+  const org = slug
+    ? slug.split('::')[0]
     : orgLookup[hubData.data.attributes.organization];
 
   if (!org) {
     recordError(
-      `No hubOrganization could be found! slug: "${hubData.data.attributes.slug}" organization: "${hubData.data.attributes.organization}"`,
+      `No hubOrganization could be found! slug: "${slug}" organization: "${hubData.data.attributes.organization}"`,
       row,
     );
   }


### PR DESCRIPTION
This finds issues such as slugs being appended with "-1" and breaking links from our website to hub.

Here are a few examples of the errors that it found during testing today:

```
|UREZ Phase 1 Solar Zones|666f6286-d7bf-43a0-9cd8-a713edd9c671|slug: "utah::utah-urez-phase-1-solar-zones-1" does not match hub name: "Utah UREZ Phase 1 Solar Zones". You may need to temporarily rename the item in Hub and then change it back to fix the slug|
|Utah Major Lakes|f3e70f49-8623-4d66-b3b2-32d777db5409|slug: "utah::utah-major-lakes-1" does not match hub name: "Utah Major Lakes". You may need to temporarily rename the item in Hub and then change it back to fix the slug|
|Watershed Restoration Initiative Treatment Areas|bfa1fa62-19b9-4315-aad1-54a23cb7968e|No "productPage" or "itemId"|
|Watersheds Area|619433b6-cdf7-4267-8a2a-3a4436a3eeac|slug: "utah::utah-watersheds-area-1" does not match hub name: "Utah Watersheds Area". You may need to temporarily rename the item in Hub and then change it back to fix the slug|
```