### PR TITLE
fix: ag protection areas links

### DIFF
--- a/src/data/downloadMetadata.ts
+++ b/src/data/downloadMetadata.ts
@@ -1754,10 +1754,12 @@ export const dataPages: DownloadMetadata = {
     layerId: 0,
   },
   'Utah Agricultural Protection Areas': {
-    itemId: 'a9fc125d02d54681aec1e5576954ded6',
+    itemId: 'ed0761f06af54f9286b21b2894d6b708',
+    externalHubOrganization: 'UDAF',
     name: 'Utah Agricultural Protection Areas',
-    featureServiceId: 'AgriculturalProtectionAreas',
-    openSgid: 'farming.agricultural_protection_areas',
+    featureServiceHost: 'https://services3.arcgis.com/yC31bwKMuDkJHWO8/arcgis/rest/services/',
+    featureServiceId: 'Agricultural_Protection_Areas',
+    openSgid: undefined,
     layerId: 0,
   },
   'Utah Tax Areas 2024': {

--- a/src/pages/products/sgid/farming/agricultural-protection-areas.astro
+++ b/src/pages/products/sgid/farming/agricultural-protection-areas.astro
@@ -25,7 +25,7 @@ export const metadata: IMetadata = {
 
 const page: IPageMetadata = {
   ...metadata,
-  updateHistory: [`October 2024`, `July 2022`],
+  updateHistory: [`April 2025`, `October 2024`, `July 2022`],
   hub: {
     ...dataPages[metadata.pageTitle],
   },


### PR DESCRIPTION
Updating `downloadMetadata.ts` to fix links to new AGOL item/services hosted by UDAF for Agricultural Protection Areas.

- https://github.com/agrc/porter/issues/392