### PR TITLE
Road update, porter changes

### DIFF
--- a/src/content/blog/2025-05-12-utah-sgid-statewide-roads-data-layer-updates.md
+++ b/src/content/blog/2025-05-12-utah-sgid-statewide-roads-data-layer-updates.md
@@ -1,0 +1,35 @@
+---
+title: Utah SGID Statewide Roads Data Layer Updates
+author: Erik Neemann
+date: 2025-05-12T08:00:00.000Z
+category: SGID Updates
+tags:
+  - roads
+cover_image: /src/images/pillar-blog/road-update-social-card.png
+cover_image_alt: ugrc sgid road update social card
+---
+
+UGRC recently completed updates to the SGID Roads data layer. Please visit our [Roads and Highway System](/products/sgid/transportation/road-centerlines/) data page where you will find information about the Roads data model, as well as a web service layer to the SGID Roads data and direct download links in shapefile and geodatabase format.
+
+These updates are also reflected in UGRC's [address locators](/products/sgid/address/).
+
+The following are highlights from this month's update.
+
+#### County Updates
+
+New roads were added and road names and address ranges were updated for the following counties:
+
+- **Davis County:** Obtained roads data on 04/15/2025. Previous update was on 03/20/2025.
+- **Piute County:** Obtained roads data on 04/15/2025. Previous update was on 10/15/2024.
+- **Salt Lake County:** Obtained roads data on 04/15/2025. Previous update was on 03/19/2025.
+- **Sevier County:** Obtained roads data on 04/23/2025. Previous update was on 10/21/2024.
+- **Summit County:** Obtained roads data on 04/30/2025. Previous update was on 04/23/2024.
+- **Utah County:** Obtained roads data on 04/24/2025. Previous update was on 03/19/2025.
+- **Wasatch County:** Obtained roads data on 04/30/2025. Previous update was on 10/21/2024.
+- **Washington County:** Obtained roads data on 04/15/2025. Previous update was on 03/19/2025.
+- **Wayne County:** Obtained roads data on 04/15/2025. Previous update was on 10/21/2024.
+- **Weber County:** Obtained roads data on 04/23/2025. Previous update was on 03/26/2025.
+
+#### UDOT Route System
+
+- Visit the [SGID LRS page](/products/sgid/transportation/highway-routes-lrs/) for information on UDOT's Advanced LRS (ALRS) data.

--- a/src/data/downloadMetadata.ts
+++ b/src/data/downloadMetadata.ts
@@ -536,13 +536,6 @@ export const dataPages: DownloadMetadata = {
     openSgid: undefined,
     layerId: 0,
   },
-  'Utah Weather Stations': {
-    itemId: 'f325911db6d9499fb935494c01fc3f94',
-    name: 'Utah Weather Stations',
-    featureServiceId: undefined,
-    openSgid: undefined,
-    layerId: 0,
-  },
   'Utah NWS Forecast Zones': {
     itemId: '93be75b42d864e889bcc3bbbf3a0dbfe',
     name: 'Utah NWS Forecast Zones',
@@ -2192,13 +2185,6 @@ export const dataPages: DownloadMetadata = {
   'Utah Stations': {
     itemId: '8a07fdbd2013420fa22eecc8fb2903ff',
     name: 'Utah Stations',
-    featureServiceId: undefined,
-    openSgid: undefined,
-    layerId: 0,
-  },
-  'Utah DDW Irrigated Crop Consumptive Use Zones': {
-    itemId: 'c5d8aef2d211443eb1e70c2ff0d87fc9',
-    name: 'Utah DDW Irrigated Crop Consumptive Use Zones',
     featureServiceId: undefined,
     openSgid: undefined,
     layerId: 0,

--- a/src/pages/products/sgid/recreation/trails-pathways.astro
+++ b/src/pages/products/sgid/recreation/trails-pathways.astro
@@ -30,6 +30,8 @@ const page: IPageMetadata = {
   ...metadata,
 
   updateHistory: [
+    'May 8, 2025',
+    'April 10, 2025',
     'March 5, 2025',
     'February 4, 2025',
     'October 10, 2024',

--- a/src/pages/products/sgid/transportation/road-centerlines.astro
+++ b/src/pages/products/sgid/transportation/road-centerlines.astro
@@ -29,6 +29,7 @@ export const metadata: IMetadata = {
 const page: IPageMetadata = {
   ...metadata,
   updateHistory: [
+    '<a href="/blog/2025-05-12-utah-sgid-statewide-roads-data-layer-updates/">May 8, 2025</a>',
     '<a href="/blog/2025-04-11-utah-sgid-statewide-roads-data-layer-updates/">April 11, 2025</a>',  
     '<a href="/blog/2025-03-07-utah-sgid-statewide-roads-data-layer-updates/">March 7, 2025</a>',  
     '<a href="/blog/2025-02-05-utah-sgid-statewide-roads-data-layer-updates/">February 5, 2025</a>',


### PR DESCRIPTION
New road update blog post, plus removing 2 deprecated layers from downloadMetadata.ts because they are now hosted in external agency AGOL.

It didn't look like there were any other changes on main, so hopefully this will be correct.