### PR TITLE
Fix Quaternary Faults links

### DIFF
--- a/src/data/downloadMetadata.ts
+++ b/src/data/downloadMetadata.ts
@@ -1292,7 +1292,7 @@ export const dataPages: DownloadMetadata = {
   'Utah Quaternary Faults': {
     itemId: '9c85978d0fb54570bc60bec467e2fa7f',
     name: 'Utah Quaternary Faults',
-    featureServiceHost: 'https://services.arcgis.com/ZzrwjTRez6FJiOq4/arcgis',
+    featureServiceHost: 'https://services.arcgis.com/ZzrwjTRez6FJiOq4/arcgis/rest/services/',
     featureServiceId: 'Utah_Quaternary_Faults_20201207',
     externalHubOrganization: 'utahDNR',
     openSgid: 'geoscience.quaternary_faults',


### PR DESCRIPTION
Davis county noticed a broken service URL for the Quaternary Faults layer on Friday.  This fixes the URL and points to the correct layer ID for DNR's [Quaternary Faults](https://www.arcgis.com/home/item.html?id=9c85978d0fb54570bc60bec467e2fa7f) layer.