### PR TITLE
Remove Urban Interface Areas (Porter)

### DIFF
--- a/src/data/downloadMetadata.ts
+++ b/src/data/downloadMetadata.ts
@@ -1676,13 +1676,6 @@ export const dataPages: DownloadMetadata = {
     openSgid: undefined,
     layerId: 0,
   },
-  'Utah Urban Interface Areas': {
-    itemId: '75fc277292c34760900bb27d8a8152fb',
-    name: 'Utah Urban Interface Areas',
-    featureServiceId: undefined,
-    openSgid: undefined,
-    layerId: 0,
-  },
   'Utah Water Related Land Use': {
     itemId: 'e3e7fc9316bb4ad09474401ff46e734f',
     name: 'Utah Water Related Land Use',


### PR DESCRIPTION
Removing the Urban Interface Areas from downloadMetadata.ts, related to a Porter deprecation [Issue 398](https://github.com/agrc/porter/issues/398).  There was no data page to remove.