### PR TITLE
fix: repairing broken and out of date links on the Knowledge page

### DIFF
--- a/src/pages/collaboration/knowledge.astro
+++ b/src/pages/collaboration/knowledge.astro
@@ -223,12 +223,12 @@ const page: IStandardPageMetadata = {
       </li>
       <li>
         <ExternalLink
-          href="https://www.esri.com/training/catalog/57630435851d31e02a43f007/getting-started-with-arcgis-pro/"
+          href="https://www.esri.com/training/catalog/5cad02469b1f4010cad9ac46/arcgis-pro-basics/"
           >Getting Started with ArcGIS Pro</ExternalLink
         > (Introduction to ArcGIS Pro)
       </li>
       <li>
-        <ExternalLink href="https://www.esri.com/training/catalog/596e584bb826875993ba4ebf/cartography./"
+        <ExternalLink href="https://www.esri.com/training/catalog/596e584bb826875993ba4ebf/cartography/"
           >Cartography MOOC</ExternalLink
         > (This is a great introduction to cartographic design principles and applications.)
       </li>
@@ -285,16 +285,16 @@ const page: IStandardPageMetadata = {
     <h4><a href="https://www.qgis.org/en/site/forusers/trainingmaterial/index.html">QGIS Training</a></h4>
     <BulletedList>
       <li>
-        <a href="https://docs.qgis.org/3.34/en/docs/gentle_gis_introduction/index.html">A Gentle Introduction to GIS</a>
+        <a href="https://docs.qgis.org/3.40/en/docs/gentle_gis_introduction/index.html">A Gentle Introduction to GIS</a>
       </li>
-      <li><a href="https://docs.qgis.org/3.34/en/docs/training_manual/index.html">QGIS Training Manual</a>.</li>
+      <li><a href="https://docs.qgis.org/3.40/en/docs/training_manual/index.html">QGIS Training Manual</a>.</li>
       <li>
         <a href="https://www.qgistutorials.com/en/"
           >QGIS Tutorials and Tips: Step-by-step guides for common QGIS tasks</a
         >
       </li>
       <li>
-        Baruch College's <a href="https://www.baruch.cuny.edu/confluence/display/geoportal/GIS+Practicum"
+        PennState's Installing and Exploring QGIS: <a href="https://www.e-education.psu.edu/geog585/node/681"
           >Introduction to GIS Using Open Source Software</a
         >
       </li>


### PR DESCRIPTION
This came up in social media planning that a handful of these links were broken/out of date. I updated some of these links with the latest coursework from Esri, and then swapped out some of the ones that were no longer available with new courses.