### PR TITLE
Add links to UGRC Shelf for tax data pages

### DIFF
--- a/src/pages/products/sgid/economy/enterprise-zones.astro
+++ b/src/pages/products/sgid/economy/enterprise-zones.astro
@@ -59,6 +59,11 @@ const page: IPageMetadata = {
       <CardWithPopularLink title="GOEO" href="https://business.utah.gov/rural/enterprise-zone-tax-credits/"
         >Governor's Office of Economic Opportunity.</CardWithPopularLink
       >
+      <CardWithPopularLink
+        title="SGID Shelf"
+        href="https://utah.maps.arcgis.com/home/group.html?sortField=title&sortOrder=desc&searchTerm=Utah+Tax&id=8765687b7b0545668fff02d1b750f7a9#content"
+        >Historical SGID Tax data.</CardWithPopularLink
+      >
       <CardWithPopularLink title="Tax" href="https://tax.utah.gov/">Utah State Tax Commission.</CardWithPopularLink>
     </GridForMoreResources>
   </Section>

--- a/src/pages/products/sgid/economy/sales-tax-areas.astro
+++ b/src/pages/products/sgid/economy/sales-tax-areas.astro
@@ -66,6 +66,11 @@ const page: IPageMetadata = {
 
   <Section title="More resources" slot="more-resources" titlePosition="center">
     <GridForMoreResources>
+      <CardWithPopularLink
+        title="SGID Shelf"
+        href="https://utah.maps.arcgis.com/home/group.html?sortField=title&sortOrder=desc&searchTerm=Utah+Tax&id=8765687b7b0545668fff02d1b750f7a9#content"
+        >Historical SGID Tax data.</CardWithPopularLink
+      >
       <CardWithPopularLink title="USTC" href="https://tax.utah.gov/">Utah State Tax Commission.</CardWithPopularLink>
       <CardWithPopularLink title="All Utah taxes and fees" href="https://tax.utah.gov/utah-taxes"
         >Descriptions of All Utah Taxes and Fees.</CardWithPopularLink

--- a/src/pages/products/sgid/economy/tax-entities.astro
+++ b/src/pages/products/sgid/economy/tax-entities.astro
@@ -7,8 +7,6 @@ import { ProductType, SgidCategory } from '@models/types';
 import HubDownloads from '@components/data/HubDownloads.astro';
 import Metadata from '@components/data/Metadata.astro';
 import UpdateHistory from '@components/data/UpdateHistory.astro';
-import Alert from '@components/page/Alert.astro';
-import ExternalLink from '@components/react/ExternalLink';
 
 import CardWithPopularLink from '@components/page/CardWithPopularLink.astro';
 import CardWithSmallLink from '@components/page/CardWithSmallLink.astro';
@@ -42,24 +40,13 @@ const page: IPageMetadata = {
   <Metadata slot="metadata" {...page} />
 
   <Fragment slot="summary">
-    <div class="grid lg:grid-cols-2 lg:gap-10">
-      <p>
-        Tax Entities 2024 contains Tax Entities in Utah. Tax Entities are incorporated bodies that have the power to
-        levy a local property tax such as school districts, counties, cities, special service districts, redevelopment
-        districts, library districts, cemetery districts, and mosquito abatement districts. The Tax Entities 2024
-        dataset does not represent exact legal boundaries, but rather a set of boundaries used for the administrative
-        purposes by the USTC Property Tax Division for centrally assesses properties (quarries, rail, linear utilities,
-        etc).
-      </p>
-      <div class="justify-center self-center">
-        <Alert title="Tip">
-          Historical tax datasets are archived in the <ExternalLink
-            href="https://utah.maps.arcgis.com/home/group.html?sortField=relevance&sortOrder=desc&searchTerm=tax&id=8765687b7b0545668fff02d1b750f7a9#content"
-            >UGRC Shelf</ExternalLink
-          > in ArcGIS Online.
-        </Alert>
-      </div>
-    </div>
+    <p>
+      Tax Entities 2024 contains Tax Entities in Utah. Tax Entities are incorporated bodies that have the power to levy
+      a local property tax such as school districts, counties, cities, special service districts, redevelopment
+      districts, library districts, cemetery districts, and mosquito abatement districts. The Tax Entities 2024 dataset
+      does not represent exact legal boundaries, but rather a set of boundaries used for the administrative purposes by
+      the USTC Property Tax Division for centrally assesses properties (quarries, rail, linear utilities, etc).
+    </p>
   </Fragment>
 
   <Section title="Use the data" slot="downloads" titlePosition="center">
@@ -85,6 +72,11 @@ const page: IPageMetadata = {
 
   <Section title="More resources" slot="more-resources" titlePosition="center">
     <GridForMoreResources>
+      <CardWithPopularLink
+        title="SGID Shelf"
+        href="https://utah.maps.arcgis.com/home/group.html?sortField=title&sortOrder=desc&searchTerm=Utah+Tax&id=8765687b7b0545668fff02d1b750f7a9#content"
+        >Historical SGID Tax data.</CardWithPopularLink
+      >
       <CardWithPopularLink title="USTC" href="https://tax.utah.gov/">Utah State Tax Commission</CardWithPopularLink>
       <CardWithPopularLink title="Property Taxes" href="https://propertytax.utah.gov/"
         >Utah Property Taxes Division</CardWithPopularLink

--- a/src/pages/products/sgid/economy/taxing-areas.astro
+++ b/src/pages/products/sgid/economy/taxing-areas.astro
@@ -72,6 +72,11 @@ const page: IPageMetadata = {
 
   <Section title="More resources" slot="more-resources" titlePosition="center">
     <GridForMoreResources>
+      <CardWithPopularLink
+        title="SGID Shelf"
+        href="https://utah.maps.arcgis.com/home/group.html?sortField=title&sortOrder=desc&searchTerm=Utah+Tax&id=8765687b7b0545668fff02d1b750f7a9#content"
+        >Historical SGID Tax data.</CardWithPopularLink
+      >
       <CardWithPopularLink title="USTC" href="https://tax.utah.gov/">Utah State Tax Commission</CardWithPopularLink>
       <CardWithPopularLink title="All Utah taxes and fees" href="https://tax.utah.gov/utah-taxes"
         >Descriptions of All Utah Taxes and Fees.</CardWithPopularLink

--- a/src/pages/products/sgid/economy/transit-special-tax-areas.astro
+++ b/src/pages/products/sgid/economy/transit-special-tax-areas.astro
@@ -58,6 +58,11 @@ const page: IPageMetadata = {
 
   <Section title="More resources" slot="more-resources" titlePosition="center">
     <GridForMoreResources>
+      <CardWithPopularLink
+        title="SGID Shelf"
+        href="https://utah.maps.arcgis.com/home/group.html?sortField=title&sortOrder=desc&searchTerm=Utah+Tax&id=8765687b7b0545668fff02d1b750f7a9#content"
+        >Historical SGID Tax data.</CardWithPopularLink
+      >
       <CardWithPopularLink title="USTC" href="https://tax.utah.gov/">Utah State Tax Commission</CardWithPopularLink>
       <CardWithPopularLink title="All Utah taxes and fees" href="https://tax.utah.gov/utah-taxes"
         >Descriptions of All Utah Taxes and Fees.</CardWithPopularLink

--- a/src/pages/products/sgid/health/health-small-statistical-areas.astro
+++ b/src/pages/products/sgid/health/health-small-statistical-areas.astro
@@ -70,9 +70,9 @@ const page: IPageMetadata = {
   <Section title="More resources" slot="more-resources" titlePosition="center">
     <GridForMoreResources>
       <CardWithPopularLink
-        title="Previous Versions"
-        href="https://utah.maps.arcgis.com/home/group.html?id=8765687b7b0545668fff02d1b750f7a9&view=list&searchTerm=small+statistical#content"
-        >Previous versions of the Health Small Statistical Areas.</CardWithPopularLink
+        title="SGID Shelf"
+        href="https://utah.maps.arcgis.com/home/group.html?sortField=relevance&sortOrder=desc&searchTerm=Utah+Health&id=8765687b7b0545668fff02d1b750f7a9#content"
+        >Historical SGID Health data.</CardWithPopularLink
       >
       <CardWithPopularLink title="Designation algorithm" href="https://ibis.health.utah.gov/pdf/resource/Algorithm.pdf"
         >Utah Local Health District and Small Area Designation Algorithm Documentation.</CardWithPopularLink

--- a/src/pages/products/sgid/location/gnis.astro
+++ b/src/pages/products/sgid/location/gnis.astro
@@ -57,6 +57,11 @@ const page: IPageMetadata = {
   <Section title="More resources" slot="more-resources" stripe titlePosition="center">
     <GridForMoreResources>
       <CardWithPopularLink
+        title="SGID Shelf"
+        href="https://utah.maps.arcgis.com/home/group.html?sortField=relevance&sortOrder=desc&searchTerm=Utah+Place+Names+GNIS&id=8765687b7b0545668fff02d1b750f7a9#content"
+        >Historical SGID GNIS data.</CardWithPopularLink
+      >
+      <CardWithPopularLink
         title="U.S. Board on Geographic Names"
         href="https://www.usgs.gov/us-board-on-geographic-names"
         >U.S. Board on Geographic Names website.</CardWithPopularLink


### PR DESCRIPTION
I created a "tip" to point users to the UGRC Shelf for historical tax datasets from their data page.  Open to other ideas or suggestions, but thought this would be a quick and easy way to point people there.