### PR TITLE
fix: law-enforcement-locations update history

### DIFF
--- a/src/pages/products/sgid/society/law-enforcement-locations.astro
+++ b/src/pages/products/sgid/society/law-enforcement-locations.astro
@@ -26,7 +26,7 @@ export const metadata: IMetadata = {
 
 const page: IPageMetadata = {
   ...metadata,
-  updateHistory: [`August 2025`, `June 2013`, `August 2011`, `November 2025`],
+  updateHistory: [`November 2025`, `August 2025`, `June 2013`, `August 2011`],
   hub: {
     ...dataPages[metadata.pageTitle],
   },


### PR DESCRIPTION
Fix the order in the update history to show the most recent update in index position 0 so it's pulled for the top of the page.