### PR TITLE
fix(sgid-index-validation): tell ky to try harder

### DIFF
--- a/scripts/validate-sgid-index.mjs
+++ b/scripts/validate-sgid-index.mjs
@@ -173,7 +173,6 @@ async function validateItemIdAndCreateHubMetadata(row) {
       limit: 5,
       retryOnTimeout: true,
     },
-    timeout: 30000
   };
 
   try {


### PR DESCRIPTION
I've noticed that this script is giving false errors requesting URLs that seem to be valid when I manually test them.