### PR TITLE
fix(sgid-validation): Add timeout option to ky request options

### DIFF
--- a/scripts/validate-sgid-index.mjs
+++ b/scripts/validate-sgid-index.mjs
@@ -173,7 +173,7 @@ async function validateItemIdAndCreateHubMetadata(row) {
       limit: 5,
       retryOnTimeout: true,
     },
-    timeout: 20000
+    timeout: 20000,
   };
 
   try {


### PR DESCRIPTION
The default timeout is 10000 (10s).