### PR TITLE
zip code boundary update

### DIFF
--- a/src/pages/products/sgid/boundaries/zip-codes.astro
+++ b/src/pages/products/sgid/boundaries/zip-codes.astro
@@ -31,6 +31,7 @@ export const metadata: IMetadata = {
 const page: IPageMetadata = {
   ...metadata,
   updateHistory: [
+    `February 2026 - Adjustment in Santa Clara to align 84765 and 84770 boundaries with USPS data`,
     `November 2025 - Salt Lake county updates on the west side to better align polygons with county address points`,
     `June 2025 - Added new Lehi zip code (84048), adjustments in Salt Lake, Summit, and Washington counties`,
     `January 2025 - Realigned Junction/Kingston boundary to match address systems and USPS data`,


### PR DESCRIPTION
Adjustment in Santa Clara to align 84765 and 84770 boundaries with USPS data