### PR TITLE
fix(sgid-index-validation): increase request timeout again

### DIFF
--- a/scripts/validate-sgid-index.mjs
+++ b/scripts/validate-sgid-index.mjs
@@ -173,7 +173,7 @@ async function validateItemIdAndCreateHubMetadata(row) {
       limit: 5,
       retryOnTimeout: true,
     },
-    timeout: 20000,
+    timeout: 40000,
   };
 
   try {


### PR DESCRIPTION
I'm still trying to get rid of false positives in the SGID Index validation process. Their still seems to be timeouts for legit requests.