### PR TITLE
fix(sgid-index-validation): Increase retry limit and timeout for requests

### DIFF
--- a/scripts/validate-sgid-index.mjs
+++ b/scripts/validate-sgid-index.mjs
@@ -170,10 +170,10 @@ async function validateItemIdAndCreateHubMetadata(row) {
 
   const kyOptions = {
     retry: {
-      limit: 5,
+      limit: 10,
       retryOnTimeout: true,
     },
-    timeout: 40000,
+    timeout: 60000,
   };
 
   try {


### PR DESCRIPTION
It's getting better but we had another false positive caused by a timeout this morning.