### PR TITLE
feat: add new accessibility page

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -251,7 +251,7 @@ const formatUrl = (path: string) => {
         <span class="border-l-2" aria-hidden="true"></span>
         <ExternalLink href="https://www.utah.gov/privacypolicy.html" type="custom">Privacy Policy</ExternalLink>
         <span class="border-l-2" aria-hidden="true"></span>
-        <ExternalLink href="https://www.utah.gov/accessibility.html" type="custom">Accessibility</ExternalLink>
+        <a href="/about/#accessibility" class="custom-style focus:outline-accent">Accessibility</a>
         <span class="border-l-2" aria-hidden="true"></span>
         <ExternalLink href="https://www.utah.gov/translate.html" type="custom">Translate</ExternalLink>
       </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,6 +5,7 @@ import type { IStandardPageMetadata } from '@models/types';
 
 import Blockquote from '@components/page/Blockquote.astro';
 import CardWithSmallLink from '@components/page/CardWithSmallLink.astro';
+import ExternalLink from '@components/page/ExternalLink.astro';
 import GridForYouMightLike from '@components/page/GridForYouMightLike.astro';
 import QuickLinks from '@components/page/QuickLinks.astro';
 import Section from '@components/page/Section.astro';
@@ -25,6 +26,7 @@ const page: IStandardPageMetadata = {
     { title: 'Who is the UGRC' },
     { title: 'What we do', titlePosition: 'center' },
     { title: 'Our vision', actionText: 'Explore our history', actionUrl: '/about/history/' },
+    { title: 'Accessibility' },
     { title: 'You might also like', titlePosition: 'center' },
   ]),
 };
@@ -80,6 +82,25 @@ const page: IStandardPageMetadata = {
     </p>
   </Section>
   <Section {...page.section[3]}>
+    <p>
+      UGRC is committed to ensuring digital accessibility for all users, including those interacting with our geospatial
+      information systems. We believe that location-based data should be inclusive. We strive to provide an equitable
+      experience that aligns with <ExternalLink
+        href="https://www.ada.gov/resources/2024-03-08-web-rule/#:~:text=Requirement:%20State%20and%20local%20governments'%20mobile%20apps%20usually%20need%20to,run%20by%20a%20private%20company"
+        >WCAG 2.1 Level AA</ExternalLink
+      > standards for all websites and applications that we maintain. If a UGRC website or application does not meet your
+      accessibility needs, please contact us at <a href="mailto:ugrc@utah.gov">ugrc@utah.gov</a>.
+    </p>
+    <p>
+      We created the <ExternalLink
+        href="https://docs.google.com/document/d/e/2PACX-1vS-Y54mTB9D7H1rVk4xmZa-8TrCitVwrE0HihpTdlQ_y6k7na45mixr9CQhMrf7R4ZxvIWQ2fLeUUWI/pub"
+        >Accessibility Action Plan</ExternalLink
+      > to serve as our formal roadmap for identifying and remediating digital barriers across our websites and GIS applications.
+      We maintain this as a living document to outline our testing procedures and remediation workflows, ensuring a consistently
+      inclusive experience for you.
+    </p>
+  </Section>
+  <Section {...page.section[4]}>
     <GridForYouMightLike>
       <CardWithSmallLink title="GIS-related Utah Statute" href="/about/code/">
         State of Utah statute and administrative rules pertaining to Geographic Information Systems & Mapping


### PR DESCRIPTION
Ref https://github.com/agrc/planning-queue/issues/960

I originally created a new page for this but it was very small and empty. Then I had the idea of adding it as a new section to our about page and linking to the section. I thought that this worked better and gave it more visibility. I still have the branch that adds it as a new page so if we want to do that it will be easy to switch.