### PR TITLE
fix: Remove disbanded GISAC subcommittee

### DIFF
--- a/src/pages/collaboration/community/user-groups/gisac.astro
+++ b/src/pages/collaboration/community/user-groups/gisac.astro
@@ -64,7 +64,6 @@ const page: IStandardPageMetadata = {
     <ul class="list-inside list-disc pl-4">
       <li>County/City Data Standards</li>
       <li>State/Federal Agency GIS Coordination</li>
-      <li>Public Service Alignment and Best Practices</li>
       <li>PLSS</li>
       <li>Utah Geodetic Advisory Committee</li>
       <li>Innovation</li>


### PR DESCRIPTION
Removed 'Public Service Alignment and Best Practices' from the list.

Closes #3358