### PR TITLE
fix: more reliable query for api-client releases

### DIFF
--- a/src/utilities/github.ts
+++ b/src/utilities/github.ts
@@ -18,13 +18,12 @@ export const getGithubReleases = async (repo: string) => {
   };
 
   if (import.meta.env.PROD) {
-    const response = await octokit.request('GET /repos/{owner}/{repo}/releases', {
+    const response = await octokit.request('GET /repos/{owner}/{repo}/releases/latest', {
       owner: 'agrc',
       repo,
-      per_page: 1,
     });
 
-    return response.data[0];
+    return response.data;
   }
 
   return releaseMetadata;


### PR DESCRIPTION
Prior to these changes, the query was returning pre-releases.

Fixes #3372