### PR TITLE
chore: remove request-info bot config

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,2 +1,0 @@
-requestInfoReplyComment: >
-  We would appreciate it if you could provide us with more info about this issue/pr!


### PR DESCRIPTION
I don't see this bot as something that is useful.

Here's an example: https://github.com/agrc/gis.utah.gov/pull/3387#issuecomment-4983388196

I've already uninstalled the bot from our org.